### PR TITLE
Add source attribution to all agent files

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: Perform thorough code reviews focusing on correctness, security, performance, and maintainability. Use when you need a fresh perspective on code quality.
+source: https://github.com/rrlamichhane/claude-agents
 color: yellow
 ---
 

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,6 +1,7 @@
 ---
 name: debugger
 description: Investigate and fix bugs systematically using root cause analysis. Use when troubleshooting errors, unexpected behavior, or system failures.
+source: https://github.com/rrlamichhane/claude-agents
 model: opus
 color: red
 ---

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,6 +1,7 @@
 ---
 name: documentation-writer
 description: Create clear, minimal documentation that follows DRY principles. Use when documentation needs to be written or improved.
+source: https://github.com/rrlamichhane/claude-agents
 color: white
 ---
 

--- a/.claude/agents/pr-refiner.md
+++ b/.claude/agents/pr-refiner.md
@@ -1,6 +1,7 @@
 ---
 name: pr-refiner
 description: Refine PRs based on review feedback. Use when receiving PR reviews, addressing reviewer comments, or systematically working through code review feedback.
+source: https://github.com/rrlamichhane/claude-agents
 color: green
 ---
 

--- a/.claude/agents/refactoring-expert.md
+++ b/.claude/agents/refactoring-expert.md
@@ -1,6 +1,7 @@
 ---
 name: refactoring-expert
 description: Improve code structure without changing behavior. Use for cleaning up technical debt, improving maintainability, or restructuring code.
+source: https://github.com/rrlamichhane/claude-agents
 color: pink
 ---
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,6 +1,7 @@
 ---
 name: security-auditor
 description: Perform security assessments identifying vulnerabilities and recommending mitigations. Use for security reviews, threat modeling, and compliance checks.
+source: https://github.com/rrlamichhane/claude-agents
 model: opus
 color: orange
 ---

--- a/.claude/agents/senior-dev.md
+++ b/.claude/agents/senior-dev.md
@@ -1,6 +1,7 @@
 ---
 name: senior-dev
 description: Implement features, fix bugs, and refactor code with production-quality standards. Use for development tasks requiring deep codebase understanding and engineering best practices.
+source: https://github.com/rrlamichhane/claude-agents
 color: cyan
 ---
 

--- a/.claude/agents/systems-architect.md
+++ b/.claude/agents/systems-architect.md
@@ -1,6 +1,7 @@
 ---
 name: systems-architect
 description: Provide high-level architectural guidance on system design, component interactions, data flows, and change impact analysis. Use for architecture questions, not implementation details.
+source: https://github.com/rrlamichhane/claude-agents
 model: opus
 color: purple
 ---

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,6 +1,7 @@
 ---
 name: tech-lead
 description: Plan implementation approaches and break down complex tasks. Use for scoping work, creating implementation plans, and making technical decisions. Does not write code.
+source: https://github.com/rrlamichhane/claude-agents
 model: opus
 color: magenta
 ---

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,6 +1,7 @@
 ---
 name: test-engineer
 description: Design and implement comprehensive test suites including unit, integration, and e2e tests. Use when you need thorough test coverage or testing strategy guidance.
+source: https://github.com/rrlamichhane/claude-agents
 color: blue
 ---
 


### PR DESCRIPTION
## Summary
- Added `source` field to frontmatter of all 10 agent files
- Points to the original repository: `https://github.com/rrlamichhane/claude-agents`
- Attribution now travels with the files when copied to other projects

## Example
```yaml
---
name: code-reviewer
description: ...
source: https://github.com/rrlamichhane/claude-agents
color: yellow
---
```

## Test plan
- [x] Validated all 10 agents have the source field
- [x] CI should pass (frontmatter validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)