### PR TITLE
fix: Update source URL in agent frontmatter to claude-code-config

### DIFF
--- a/.claude/agents/agent-specialist.md
+++ b/.claude/agents/agent-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: agent-specialist
 description: Design, build, and optimize AI agents with strong output contracts, guardrails, and behavioral consistency. Use when creating or improving agent prompts.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: yellow

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Perform thorough code reviews focusing on correctness, security, performance, and maintainability. Use when you need a fresh perspective on code quality.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: yellow
 ---

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Investigate and fix bugs systematically using root cause analysis. Use when troubleshooting errors, unexpected behavior, or system failures.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: red

--- a/.claude/agents/digital-designer.md
+++ b/.claude/agents/digital-designer.md
@@ -1,7 +1,7 @@
 ---
 name: digital-designer
 description: Create print-ready digital designs including booklets, brochures, flyers, and posters. Use when designing layouts that need to be printed or converted to PDF.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: magenta

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-writer
 description: Create clear, minimal documentation that follows DRY principles. Use when documentation needs to be written or improved.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: white
 ---

--- a/.claude/agents/pr-refiner.md
+++ b/.claude/agents/pr-refiner.md
@@ -1,7 +1,7 @@
 ---
 name: pr-refiner
 description: Refine PRs based on review feedback. Use when receiving PR reviews, addressing reviewer comments, or systematically working through code review feedback.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: green
 ---

--- a/.claude/agents/prod-engineer.md
+++ b/.claude/agents/prod-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: prod-engineer
 description: Triage production incidents, diagnose with evidence, apply safe mitigations, and harden systems. Use for outages, performance issues, infrastructure problems, and reliability engineering.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: red

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -1,7 +1,7 @@
 ---
 name: product-owner
 description: Define product direction, prioritize for value, write specs, and make clear decisions. Use for feature planning, PRDs, user stories, roadmaps, and stakeholder alignment.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: magenta
 ---

--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-engineer
 description: Engineer effective prompts for AI models. Asks clarifying questions to understand requirements, then crafts concise, well-organized prompts optimized for the target model.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: cyan

--- a/.claude/agents/refactoring-expert.md
+++ b/.claude/agents/refactoring-expert.md
@@ -1,7 +1,7 @@
 ---
 name: refactoring-expert
 description: Improve code structure without changing behavior. Use for cleaning up technical debt, improving maintainability, or restructuring code.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: pink
 ---

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Perform security assessments identifying vulnerabilities and recommending mitigations. Use for security reviews, threat modeling, and compliance checks.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: orange

--- a/.claude/agents/senior-dev.md
+++ b/.claude/agents/senior-dev.md
@@ -1,7 +1,7 @@
 ---
 name: senior-dev
 description: Implement features, fix bugs, and refactor code with production-quality standards. Use for development tasks requiring deep codebase understanding and engineering best practices.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: cyan
 ---

--- a/.claude/agents/solution-eng.md
+++ b/.claude/agents/solution-eng.md
@@ -1,7 +1,7 @@
 ---
 name: solution-eng
 description: Bridge product capabilities and customer needs with technical accuracy and deal momentum. Use for discovery, solution design, demos, POCs, and technical sales support.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: green
 ---

--- a/.claude/agents/systems-architect.md
+++ b/.claude/agents/systems-architect.md
@@ -1,7 +1,7 @@
 ---
 name: systems-architect
 description: Provide high-level architectural guidance on system design, component interactions, data flows, and change impact analysis. Use for architecture questions, not implementation details.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: purple

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,7 +1,7 @@
 ---
 name: tech-lead
 description: Plan implementation approaches and break down complex tasks. Use for scoping work, creating implementation plans, and making technical decisions. Does not write code.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: magenta

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Design and implement comprehensive test suites including unit, integration, and e2e tests. Use when you need thorough test coverage or testing strategy guidance.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: blue
 ---


### PR DESCRIPTION
## Summary
- Update the `source` field in YAML frontmatter across all 16 agent markdown files from `https://github.com/amulya-labs/claude-agents` to `https://github.com/amulya-labs/claude-code-config`

## Changes
- `.claude/agents/agent-specialist.md` - updated `source` frontmatter field
- `.claude/agents/code-reviewer.md` - updated `source` frontmatter field
- `.claude/agents/debugger.md` - updated `source` frontmatter field
- `.claude/agents/digital-designer.md` - updated `source` frontmatter field
- `.claude/agents/documentation-writer.md` - updated `source` frontmatter field
- `.claude/agents/pr-refiner.md` - updated `source` frontmatter field
- `.claude/agents/prod-engineer.md` - updated `source` frontmatter field
- `.claude/agents/product-owner.md` - updated `source` frontmatter field
- `.claude/agents/prompt-engineer.md` - updated `source` frontmatter field
- `.claude/agents/refactoring-expert.md` - updated `source` frontmatter field
- `.claude/agents/security-auditor.md` - updated `source` frontmatter field
- `.claude/agents/senior-dev.md` - updated `source` frontmatter field
- `.claude/agents/solution-eng.md` - updated `source` frontmatter field
- `.claude/agents/systems-architect.md` - updated `source` frontmatter field
- `.claude/agents/tech-lead.md` - updated `source` frontmatter field
- `.claude/agents/test-engineer.md` - updated `source` frontmatter field

## Test plan
- [x] Verified zero remaining references to old `claude-agents` URL in `.claude/agents/`
- [x] Verified all 16 files contain the new `claude-code-config` URL