### PR TITLE
chore: Rename repo references from claude-agents to claude-code-config

### DIFF
--- a/.claude/agents/agent-specialist.md
+++ b/.claude/agents/agent-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: agent-specialist
 description: Design, build, and optimize AI agents with strong output contracts, guardrails, and behavioral consistency. Use when creating or improving agent prompts.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: yellow

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Perform thorough code reviews focusing on correctness, security, performance, and maintainability. Use when you need a fresh perspective on code quality.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: yellow
 ---

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Investigate and fix bugs systematically using root cause analysis. Use when troubleshooting errors, unexpected behavior, or system failures.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: red

--- a/.claude/agents/digital-designer.md
+++ b/.claude/agents/digital-designer.md
@@ -1,7 +1,7 @@
 ---
 name: digital-designer
 description: Create print-ready digital designs including booklets, brochures, flyers, and posters. Use when designing layouts that need to be printed or converted to PDF.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: magenta

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-writer
 description: Create clear, minimal documentation that follows DRY principles. Use when documentation needs to be written or improved.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: white
 ---

--- a/.claude/agents/pr-refiner.md
+++ b/.claude/agents/pr-refiner.md
@@ -1,7 +1,7 @@
 ---
 name: pr-refiner
 description: Refine PRs based on review feedback. Use when receiving PR reviews, addressing reviewer comments, or systematically working through code review feedback.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: green
 ---

--- a/.claude/agents/prod-engineer.md
+++ b/.claude/agents/prod-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: prod-engineer
 description: Triage production incidents, diagnose with evidence, apply safe mitigations, and harden systems. Use for outages, performance issues, infrastructure problems, and reliability engineering.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: red

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -1,7 +1,7 @@
 ---
 name: product-owner
 description: Define product direction, prioritize for value, write specs, and make clear decisions. Use for feature planning, PRDs, user stories, roadmaps, and stakeholder alignment.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: magenta
 ---

--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-engineer
 description: Engineer effective prompts for AI models. Asks clarifying questions to understand requirements, then crafts concise, well-organized prompts optimized for the target model.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: cyan

--- a/.claude/agents/refactoring-expert.md
+++ b/.claude/agents/refactoring-expert.md
@@ -1,7 +1,7 @@
 ---
 name: refactoring-expert
 description: Improve code structure without changing behavior. Use for cleaning up technical debt, improving maintainability, or restructuring code.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: pink
 ---

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Perform security assessments identifying vulnerabilities and recommending mitigations. Use for security reviews, threat modeling, and compliance checks.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: orange

--- a/.claude/agents/senior-dev.md
+++ b/.claude/agents/senior-dev.md
@@ -1,7 +1,7 @@
 ---
 name: senior-dev
 description: Implement features, fix bugs, and refactor code with production-quality standards. Use for development tasks requiring deep codebase understanding and engineering best practices.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: cyan
 ---

--- a/.claude/agents/solution-eng.md
+++ b/.claude/agents/solution-eng.md
@@ -1,7 +1,7 @@
 ---
 name: solution-eng
 description: Bridge product capabilities and customer needs with technical accuracy and deal momentum. Use for discovery, solution design, demos, POCs, and technical sales support.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: green
 ---

--- a/.claude/agents/systems-architect.md
+++ b/.claude/agents/systems-architect.md
@@ -1,7 +1,7 @@
 ---
 name: systems-architect
 description: Provide high-level architectural guidance on system design, component interactions, data flows, and change impact analysis. Use for architecture questions, not implementation details.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: purple

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,7 +1,7 @@
 ---
 name: tech-lead
 description: Plan implementation approaches and break down complex tasks. Use for scoping work, creating implementation plans, and making technical decisions. Does not write code.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus
 color: magenta

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Design and implement comprehensive test suites including unit, integration, and e2e tests. Use when you need thorough test coverage or testing strategy guidance.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 color: blue
 ---

--- a/.claude/hooks/bash-patterns.toml
+++ b/.claude/hooks/bash-patterns.toml
@@ -1,7 +1,7 @@
 # Bash command validation patterns for Claude Code PreToolUse hook
 # Patterns are regular expressions matched against commands
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 #
 # Categories:

--- a/.claude/hooks/post-bash.sh
+++ b/.claude/hooks/post-bash.sh
@@ -2,7 +2,7 @@
 # Claude Code PostToolUse hook for Bash commands
 # Logs ASK command outcomes (approved)
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/hooks/validate-bash.py
+++ b/.claude/hooks/validate-bash.py
@@ -3,7 +3,7 @@
 Bash command validator for Claude Code PreToolUse hook.
 Reads patterns from TOML config and validates commands.
 
-Source: https://github.com/amulya-labs/claude-agents
+Source: https://github.com/amulya-labs/claude-code-config
 License: MIT (https://opensource.org/licenses/MIT)
 """
 

--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -3,7 +3,7 @@
 # Validates commands against patterns defined in bash-patterns.toml
 # Handles command combinations (pipes, chains, subshells)
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 
 set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
           for script in .claude/hooks/*.sh scripts/*.sh scripts/git-subtree-mgr; do
             if [ -f "$script" ]; then
               echo -n "Checking $script... "
-              if ! grep -q "Source:.*github.com/amulya-labs/claude-agents" "$script"; then
+              if ! grep -q "Source:.*github.com/amulya-labs/claude-code-config" "$script"; then
                 echo "MISSING source attribution"
                 errors=$((errors + 1))
               elif ! grep -qi "License:.*MIT" "$script"; then
@@ -192,7 +192,7 @@ jobs:
           for script in .claude/hooks/*.py; do
             if [ -f "$script" ]; then
               echo -n "Checking $script... "
-              if ! grep -q "Source:.*github.com/amulya-labs/claude-agents" "$script"; then
+              if ! grep -q "Source:.*github.com/amulya-labs/claude-code-config" "$script"; then
                 echo "MISSING source attribution"
                 errors=$((errors + 1))
               elif ! grep -qi "License:.*MIT" "$script"; then
@@ -209,7 +209,7 @@ jobs:
           for config in .claude/hooks/*.toml; do
             if [ -f "$config" ]; then
               echo -n "Checking $config... "
-              if ! grep -q "Source:.*github.com/amulya-labs/claude-agents" "$config"; then
+              if ! grep -q "Source:.*github.com/amulya-labs/claude-code-config" "$config"; then
                 echo "MISSING source attribution"
                 errors=$((errors + 1))
               elif ! grep -qi "License:.*MIT" "$config"; then
@@ -226,7 +226,7 @@ jobs:
             echo "ERROR: $errors file(s) missing proper attributions"
             echo ""
             echo "Required format for scripts:"
-            echo "  # Source: https://github.com/amulya-labs/claude-agents"
+            echo "  # Source: https://github.com/amulya-labs/claude-code-config"
             echo "  # License: MIT (https://opensource.org/licenses/MIT)"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ PRs welcome. When adding or improving agents, ensure they are generalized, focus
 ---
 name: agent-name
 description: Brief description of when to use this agent.
-source: https://github.com/amulya-labs/claude-agents
+source: https://github.com/amulya-labs/claude-code-config
 license: MIT
 model: opus  # optional: opus, sonnet, haiku (omit for default)
 color: blue  # optional: terminal color

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Claude Agents
+# Claude Code Config
 
-[![CI](https://github.com/amulya-labs/claude-agents/actions/workflows/ci.yml/badge.svg)](https://github.com/amulya-labs/claude-agents/actions/workflows/ci.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/amulya-labs/claude-agents/badge)](https://scorecard.dev/viewer/?uri=github.com/amulya-labs/claude-agents)
+[![CI](https://github.com/amulya-labs/claude-code-config/actions/workflows/ci.yml/badge.svg)](https://github.com/amulya-labs/claude-code-config/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/amulya-labs/claude-code-config/badge)](https://scorecard.dev/viewer/?uri=github.com/amulya-labs/claude-code-config)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Agents](https://img.shields.io/badge/agents-16-blue.svg)](.claude/agents/)
 
-**Plug-and-play AI teammates for Claude Code.** Drop specialized agents into any project and delegate planning, coding, debugging, reviews, and more.
+**Production-ready configuration for Claude Code.** Agents, hooks, and settings you can drop into any project.
 
 ## Quick Install
 
 ```bash
-mkdir -p scripts && curl -fsSL -o scripts/manage-agents.sh https://raw.githubusercontent.com/amulya-labs/claude-agents/main/scripts/manage-agents.sh && chmod +x scripts/manage-agents.sh && ./scripts/manage-agents.sh install
+mkdir -p scripts && curl -fsSL -o scripts/manage-agents.sh https://raw.githubusercontent.com/amulya-labs/claude-code-config/main/scripts/manage-agents.sh && chmod +x scripts/manage-agents.sh && ./scripts/manage-agents.sh install
 ```
 
 ## What You Get
@@ -98,7 +98,7 @@ Claude can also select agents automatically based on your request.
 
 ```bash
 mkdir -p scripts
-curl -fsSL -o scripts/manage-agents.sh https://raw.githubusercontent.com/amulya-labs/claude-agents/main/scripts/manage-agents.sh
+curl -fsSL -o scripts/manage-agents.sh https://raw.githubusercontent.com/amulya-labs/claude-code-config/main/scripts/manage-agents.sh
 chmod +x scripts/manage-agents.sh
 ./scripts/manage-agents.sh install
 ```
@@ -109,11 +109,11 @@ Update later with `./scripts/manage-agents.sh update`.
 
 ```bash
 # Install the manager globally
-curl -fsSL -o ~/bin/git-subtree-mgr https://raw.githubusercontent.com/amulya-labs/claude-agents/main/scripts/git-subtree-mgr
+curl -fsSL -o ~/bin/git-subtree-mgr https://raw.githubusercontent.com/amulya-labs/claude-code-config/main/scripts/git-subtree-mgr
 chmod +x ~/bin/git-subtree-mgr
 
 # Add .claude as a subtree
-git-subtree-mgr add --prefix=.claude --repo=amulya-labs/claude-agents --path=.claude
+git-subtree-mgr add --prefix=.claude --repo=amulya-labs/claude-code-config --path=.claude
 ```
 
 Update later with `git-subtree-mgr pull .claude`.
@@ -121,8 +121,8 @@ Update later with `git-subtree-mgr pull .claude`.
 ### Option 3: Manual Copy
 
 ```bash
-git clone https://github.com/amulya-labs/claude-agents.git
-cp -r claude-agents/.claude/ /path/to/your/project/.claude/
+git clone https://github.com/amulya-labs/claude-code-config.git
+cp -r claude-code-config/.claude/ /path/to/your/project/.claude/
 ```
 
 </details>

--- a/scripts/git-subtree-mgr
+++ b/scripts/git-subtree-mgr
@@ -5,7 +5,7 @@ set -e
 # A generic script to manage git subtrees across any repository
 # Supports pulling subdirectories from remote repos (not just entire repos)
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 #
 # Place this in your ~/bin and use it from any git repo
@@ -56,7 +56,7 @@ Examples:
   $(basename "$0") add --prefix=vendor/lib --repo=someone/lib
 
   # Add only a subdirectory from the repo
-  $(basename "$0") add --prefix=.claude/agents --repo=amulya-labs/claude-agents --path=.claude/agents
+  $(basename "$0") add --prefix=.claude/agents --repo=amulya-labs/claude-code-config --path=.claude/agents
 
   # Pull updates
   $(basename "$0") pull

--- a/scripts/manage-agents.sh
+++ b/scripts/manage-agents.sh
@@ -4,14 +4,14 @@ set -e
 # Claude Code Config Manager
 # Copy this script to your project and use it to install/update .claude config
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 #
 # Usage:
 #   ./scripts/manage-agents.sh install   # First-time setup
 #   ./scripts/manage-agents.sh update    # Pull latest config
 
-REPO="amulya-labs/claude-agents"
+REPO="amulya-labs/claude-code-config"
 BRANCH="main"
 CLAUDE_DIR=".claude"
 API_BASE="https://api.github.com/repos/$REPO/contents"

--- a/tests/bash-test-cases.toml
+++ b/tests/bash-test-cases.toml
@@ -2,7 +2,7 @@
 # Format: Each section contains test cases for a specific category
 # Each test case has: command, expected (allow|ask|deny), description
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 
 # =============================================================================

--- a/tests/test-validate-bash.sh
+++ b/tests/test-validate-bash.sh
@@ -3,7 +3,7 @@
 # Reads test cases from bash-test-cases.toml
 # Exit codes: 0 = all tests pass, 1 = failures
 #
-# Source: https://github.com/amulya-labs/claude-agents
+# Source: https://github.com/amulya-labs/claude-code-config
 # License: MIT (https://opensource.org/licenses/MIT)
 
 set -euo pipefail

--- a/tests/test_validate_bash.py
+++ b/tests/test_validate_bash.py
@@ -4,7 +4,7 @@ Data-driven parametrized tests for the Bash command validator.
 Loads test cases from bash-test-cases.toml and tests the validator
 directly (no shell wrapper overhead).
 
-Source: https://github.com/amulya-labs/claude-agents
+Source: https://github.com/amulya-labs/claude-code-config
 License: MIT (https://opensource.org/licenses/MIT)
 """
 


### PR DESCRIPTION
## Summary
- Renamed all references from `claude-agents` to `claude-code-config` across 28 files
- Updated README title and description to reflect the broader scope (agents, hooks, settings)
- Updated source attribution URLs in all agents, hooks, scripts, tests, and CI workflow

## Test plan
- [x] All 228 bash hook tests pass
- [x] TOML config validation passes
- [x] Agent frontmatter validation passes (16/16 valid)
- [x] Attribution check passes (matches CI's grep patterns)
- [ ] CI pipeline passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)