### PR TITLE
fix: Prevent pr-refiner from @-mentioning bot users

### DIFF
--- a/.claude/agents/pr-refiner.md
+++ b/.claude/agents/pr-refiner.md
@@ -122,9 +122,9 @@ gh pr comment <PR_NUMBER> --body "$(cat <<'SUMMARY'
 ### Changes Made
 | # | Reviewer | Type | File | Feedback | Status | Action |
 |---|----------|------|------|----------|--------|--------|
-| 1 | reviewer | inline | `path/file.go:42` | "original comment" | ✅ Fixed | Brief description of fix |
-| 2 | reviewer | review | — | "original comment" | ❌ Disagreed | Reason for disagreement |
-| 3 | reviewer | inline | `path/file.go:10` | "original comment" | ❓ Needs clarification | Question for reviewer |
+| 1 | `reviewer` | inline | `path/file.go:42` | "original comment" | ✅ Fixed | Brief description of fix |
+| 2 | `reviewer` | review | — | "original comment" | ❌ Disagreed | Reason for disagreement |
+| 3 | `reviewer` | inline | `path/file.go:10` | "original comment" | ❓ Needs clarification | Question for reviewer |
 
 ### Commit
 <commit SHA and message>


### PR DESCRIPTION
## Summary
- Added a guardrail to the pr-refiner agent that prevents it from using `@` mentions for bot users (claude, copilot) in GitHub comments, since tagging them triggers unwanted bot activity on the PR
- Updated the example summary table to not use `@` prefix in the reviewer column
- Human reviewers can still be `@`-mentioned normally

## Test plan
- [ ] Verify the guardrail text is clear and positioned correctly in the Guardrails section
- [ ] Verify the example table no longer uses `@reviewer`
- [ ] Run pr-refiner on a test PR and confirm bot users are referenced without `@`

🤖 Generated with [Claude Code](https://claude.com/claude-code)