### PR TITLE
fix: comma-join repomix --include/--ignore patterns (#92)

### DIFF
--- a/.github/workflows/sync-notebooklm.yml
+++ b/.github/workflows/sync-notebooklm.yml
@@ -110,10 +110,13 @@ jobs:
               cmd = ["repomix", "--style", "plain", "--output", output_file]
               if os.path.isfile(".github/repomix.config.json"):
                   cmd.extend(["--config", ".github/repomix.config.json"])
-              for pattern in include:
-                  cmd.extend(["--include", pattern])
-              for pattern in ignore:
-                  cmd.extend(["--ignore", pattern])
+              # repomix --include / --ignore each take a single comma-separated
+              # value, not repeatable flags. Passing multiple flags causes only
+              # the last one to apply. Join the lists into one value each.
+              if include:
+                  cmd.extend(["--include", ",".join(include)])
+              if ignore:
+                  cmd.extend(["--ignore", ",".join(ignore)])
               cmd.append(".")
 
               print(f"\n{'='*60}")


### PR DESCRIPTION
## Summary
- Fixes #92: `sync-notebooklm.yml` was emitting one `--include`/`--ignore` flag per pattern, but repomix expects a single comma-separated value per flag — only the final pattern survived, so any source with >1 include pattern silently dropped earlier matches.
- Joins each list into one comma-separated argument and skips the flag entirely when the list is empty.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/sync-notebooklm.yml'))"` — workflow YAML still parses
- [x] Full local CI-equivalent (`shellcheck`, TOML load, `pytest tests/test_validate_bash.py`, `tests/test-validate-bash.sh`, `tests/test-manage-agents.sh`) — all green
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)