### PR TITLE
fix: pin PR checkout to immutable SHA to prevent TOCTOU race (CodeQL #68)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -150,7 +150,7 @@ jobs:
           # PR content is accessed exclusively via gh API commands.
           # For non-public repos, check out the PR head so local file tools (Read/Glob/Grep) work.
           # The ref is pinned to an immutable SHA (resolved above) to prevent TOCTOU race conditions.
-          ref: ${{ steps.meta.outputs.is_public == 'true' && github.event.repository.default_branch || (steps.sha.outputs.value != '' && steps.sha.outputs.value || github.ref) }}
+          ref: ${{ steps.meta.outputs.is_public == 'true' && github.event.repository.default_branch || steps.sha.outputs.value }}
 
       - name: Post review-started notice
         if: github.event_name != 'pull_request' || github.event.action == 'review_requested'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -123,6 +123,24 @@ jobs:
             "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='eyes'
 
+      - name: Resolve head SHA
+        id: sha
+        if: steps.meta.outputs.is_public == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # SECURITY: Snapshot the PR head SHA once at job start to prevent TOCTOU attacks.
+          # An attacker cannot force-push malicious code after this point because we pin
+          # the checkout to this immutable SHA rather than the mutable refs/pull/N/head ref.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            SHA=$(gh pr view "${{ steps.pr.outputs.number }}" \
+              --repo "${{ github.repository }}" \
+              --json headRefOid --jq .headRefOid)
+            echo "value=$SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -131,7 +149,8 @@ jobs:
           # The claude-code-action restores .claude/ config from this trusted base.
           # PR content is accessed exclusively via gh API commands.
           # For non-public repos, check out the PR head so local file tools (Read/Glob/Grep) work.
-          ref: ${{ steps.meta.outputs.is_public == 'true' && github.event.repository.default_branch || (steps.pr.outputs.number != '' && format('refs/pull/{0}/head', steps.pr.outputs.number) || github.ref) }}
+          # The ref is pinned to an immutable SHA (resolved above) to prevent TOCTOU race conditions.
+          ref: ${{ steps.meta.outputs.is_public == 'true' && github.event.repository.default_branch || (steps.sha.outputs.value != '' && steps.sha.outputs.value || github.ref) }}
 
       - name: Post review-started notice
         if: github.event_name != 'pull_request' || github.event.action == 'review_requested'

--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -71,12 +71,27 @@ jobs:
             "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='eyes'
 
+      - name: Resolve head SHA
+        id: sha
+        if: steps.meta.outputs.is_public == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # SECURITY: Snapshot the PR head SHA once at job start to prevent TOCTOU attacks.
+          # An attacker cannot force-push malicious code after this point because we pin
+          # the checkout to this immutable SHA rather than the mutable refs/pull/N/head ref.
+          SHA=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefOid --jq .headRefOid)
+          echo "value=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository (non-public only)
         if: steps.meta.outputs.is_public == 'false'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          # SECURITY: Pinned to immutable SHA (resolved above) to prevent TOCTOU race conditions.
+          ref: ${{ steps.sha.outputs.value }}
 
       - name: Checkout default branch (public only)
         if: steps.meta.outputs.is_public == 'true'


### PR DESCRIPTION
## Summary

Closes CodeQL alert #68 (`actions/untrusted-checkout-toctou/critical`).

Both `claude-code-review.yml` and `gemini-code-review.yml` previously checked out `refs/pull/<N>/head` — a **mutable** ref — on the non-public path. An attacker who opened a PR from a fork could:

1. Submit a benign diff and wait for a COLLABORATOR/MEMBER/OWNER to type `/claude-review` or `/gemini-review`.
2. Force-push malicious code to the PR head **after** the `author_association` gate passed but **before** the checkout step ran.
3. Have the workflow execute the mutated code with `pull-requests: write`, `issues: write`, and access to `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY`.

## Fix

Added a **"Resolve head SHA"** step that runs on the non-public path **before** the checkout step. It snapshots the PR head SHA once at job start (from the immutable event payload for `pull_request` events, or via `gh pr view --json headRefOid` for `issue_comment` / `workflow_dispatch`). The checkout `ref:` is then pinned to this immutable SHA.

- **`claude-code-review.yml`**: new `Resolve head SHA` step (id: `sha`); checkout ternary updated from `format('refs/pull/{0}/head', steps.pr.outputs.number)` to `steps.sha.outputs.value`.
- **`gemini-code-review.yml`**: new `Resolve head SHA` step inserted before the non-public checkout; `ref:` changed from `refs/pull/${{ github.event.issue.number }}/head` to `${{ steps.sha.outputs.value }}`.
- The **public path** is unchanged — it already checks out the default branch, which is correct.

## Changes

- `.github/workflows/claude-code-review.yml` — add `Resolve head SHA` step; update non-public checkout ref
- `.github/workflows/gemini-code-review.yml` — add `Resolve head SHA` step; update non-public checkout ref

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` — YAML valid
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/gemini-code-review.yml'))"` — YAML valid
- [x] Full CI-equivalent (`shellcheck`, TOML validation, pytest, shell integration tests, manage-agents tests) — all pass
- [ ] Verify CodeQL alert #68 is dismissed after merge