### PR TITLE
[codex] Add shared /review trigger for code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,8 @@ concurrency:
       ||
     (github.event_name == 'issue_comment' &&
      github.event.issue.pull_request &&
-     startsWith(github.event.comment.body, '/claude-review') &&
+     (startsWith(github.event.comment.body, '/review') ||
+      startsWith(github.event.comment.body, '/claude-review')) &&
      github.actor != 'claude[bot]') &&
       format('{0}-issue_comment-pr-{1}', github.workflow, github.event.issue.number)
       ||
@@ -42,8 +43,8 @@ concurrency:
 jobs:
   claude-review:
     # Unified job: handles both public and non-public repos.
-    # For non-public repos: triggers on workflow_dispatch, same-repo pull_request, or authorized /claude-review comment.
-    # For public repos: triggers on authorized pull_request (MEMBER/OWNER/COLLABORATOR), workflow_dispatch with pr_number, or authorized /claude-review comment.
+    # For non-public repos: triggers on workflow_dispatch, same-repo pull_request, or authorized /review or /claude-review comment.
+    # For public repos: triggers on authorized pull_request (MEMBER/OWNER/COLLABORATOR), workflow_dispatch with pr_number, or authorized /review or /claude-review comment.
     if: |
       (
         github.event.repository.visibility != 'public' && (
@@ -52,7 +53,8 @@ jobs:
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            startsWith(github.event.comment.body, '/claude-review') &&
+            (startsWith(github.event.comment.body, '/review') ||
+             startsWith(github.event.comment.body, '/claude-review')) &&
             !contains(github.event.comment.body, '@claude') &&
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
           )
@@ -62,7 +64,8 @@ jobs:
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            startsWith(github.event.comment.body, '/claude-review') &&
+            (startsWith(github.event.comment.body, '/review') ||
+             startsWith(github.event.comment.body, '/claude-review')) &&
             !contains(github.event.comment.body, '@claude') &&
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
           ) ||
@@ -161,7 +164,7 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
         run: |
           case "$EVENT_NAME" in
-            issue_comment) TRIGGER="\`/claude-review\`" ;;
+            issue_comment) TRIGGER="\`/review\` or \`/claude-review\`" ;;
             pull_request)  TRIGGER="PR $EVENT_ACTION" ;;
             *)             TRIGGER="workflow dispatch" ;;
           esac
@@ -367,7 +370,7 @@ jobs:
           > 🤖 **Note:** The automated Claude code review did not complete — $REASON.
           >
           > Any inline comments posted above are valid findings, but the review may be incomplete.
-          > [View workflow run]($RUN_URL) for details. Re-trigger with \`/claude-review\`.
+          > [View workflow run]($RUN_URL) for details. Re-trigger with \`/review\` or \`/claude-review\`.
           EOF
 
           gh pr comment "$PR_NUM" \

--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -14,7 +14,8 @@ on:
 concurrency:
   group: ${{
     (github.event.issue.pull_request &&
-     (startsWith(github.event.comment.body, '/gemini-light-review') ||
+     (startsWith(github.event.comment.body, '/review') ||
+      startsWith(github.event.comment.body, '/gemini-light-review') ||
       startsWith(github.event.comment.body, '/gemini-deep-review') ||
       startsWith(github.event.comment.body, '/gemini-pro-review') ||
       startsWith(github.event.comment.body, '/gemini-review'))) &&
@@ -32,6 +33,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       (
+        startsWith(github.event.comment.body, '/review') ||
         startsWith(github.event.comment.body, '/gemini-light-review') ||
         startsWith(github.event.comment.body, '/gemini-deep-review') ||
         startsWith(github.event.comment.body, '/gemini-pro-review') ||
@@ -208,6 +210,7 @@ jobs:
           if [[ "$COMMENT_BODY" == /gemini-pro-review* ]]; then RETRIGGER="/gemini-pro-review"
           elif [[ "$COMMENT_BODY" == /gemini-deep-review* ]]; then RETRIGGER="/gemini-deep-review"
           elif [[ "$COMMENT_BODY" == /gemini-light-review* ]]; then RETRIGGER="/gemini-light-review"
+          elif [[ "$COMMENT_BODY" == /review* ]]; then RETRIGGER="/review"
           else RETRIGGER="/gemini-review"; fi
 
           cat > /tmp/failure-notice.md <<EOF

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Run `./scripts/manage-ai-configs.sh` or `git-subtree-mgr --help` for usage.
 
 | Workflow | Purpose | Trigger |
 |----------|---------|---------|
-| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/claude-review` comment |
-| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | PR opened/updated; `/gemini-review` comment |
+| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/review` or `/claude-review` comment |
+| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | `/review` or `/gemini-review` comment |
 | `sync-notebooklm.yml` | Flatten repo into text sources and sync to NotebookLM | Push to main; manual dispatch |
 
 ### Gemini Code Review Setup
@@ -174,7 +174,11 @@ Add your Gemini API key as a repository secret named `GEMINI_API_KEY`. The workf
 - **Gemini Flash** for the narrative PR summary (fast, quota-efficient)
 - **Gemini Pro** for line-level inline comments (deep reasoning)
 
-Trigger manually by commenting `/gemini-review` on any PR (members/owners/collaborators only).
+Trigger manually by commenting `/review` or `/gemini-review` on any PR (members/owners/collaborators only).
+
+### Shared Review Command Convention
+
+All `*-code-review.yml` workflows should opt in to the shared `/review` PR comment trigger alongside any agent-specific commands such as `/claude-review` or `/gemini-review`. This keeps the default review fan-out convention-based and avoids a separate dispatcher workflow.
 
 ### NotebookLM Sync
 


### PR DESCRIPTION
## Summary
Add a shared `/review` PR comment trigger that fans out to the default code-review workflows alongside the existing agent-specific commands.

## What Changed
- Updated `claude-code-review.yml` to accept `/review` in the comment-trigger concurrency and job guards.
- Updated `gemini-code-review.yml` to accept `/review` in the comment-trigger guards and retrigger messaging.
- Documented the shared `/review` convention in `README.md` so future `*-code-review.yml` workflows opt in by default.

## Why
Issue #96 proposes a single review command so users do not need to remember and post separate comments for each reviewer.

## Impact
PR authors and reviewers can now comment `/review` once to trigger the default review fan-out, while `/claude-review` and `/gemini-review` continue to work.

## Validation
- `git diff --check`
