### PR TITLE
Make Bash hook policy reusable across Claude, Gemini CLI, and Codex

### DIFF
--- a/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.darwin.toml
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.darwin.toml
@@ -3,14 +3,6 @@
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
-#
-# These patterns extend the universal base patterns with macOS-specific commands.
-# Sections with the same name as base sections have their patterns APPENDED.
-# New sections are added as-is.
-
-# =============================================================================
-# DENY PATTERNS - macOS-specific catastrophic operations
-# =============================================================================
 
 [deny.system_shutdown]
 description = "macOS shutdown/reboot (extends base)"
@@ -18,10 +10,6 @@ patterns = [
     "^osascript -e.*shut down",
     "^osascript -e.*restart",
 ]
-
-# =============================================================================
-# ASK PATTERNS - macOS-specific risky operations
-# =============================================================================
 
 [ask.service_management]
 description = "macOS service management (extends base)"
@@ -71,10 +59,6 @@ patterns = [
     "^diskutil (erase|partition|mount|unmount|rename|resize|apfs)",
     "^hdiutil (create|attach|detach|convert|resize)",
 ]
-
-# =============================================================================
-# ALLOW PATTERNS - macOS-specific safe operations
-# =============================================================================
 
 [allow.system_readonly]
 description = "macOS read-only system inspection (extends base)"
@@ -142,7 +126,6 @@ patterns = [
 [allow.macos_open_url]
 description = "macOS open command for URLs and safe targets"
 patterns = [
-    # open for directories and specific safe apps
     "^open \\.$",
     "^open \\.\\.$",
     "^open ~/",

--- a/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.linux.toml
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.linux.toml
@@ -7,14 +7,6 @@
 # These patterns extend the universal base patterns with Linux-specific commands.
 # Sections with the same name as base sections have their patterns APPENDED.
 # New sections are added as-is.
-#
-# NOTE: Many Linux commands are already in the base file (bash-patterns.toml)
-# because they were the original defaults. This file adds patterns that were
-# previously missing or are unique to Linux distributions.
-
-# =============================================================================
-# ASK PATTERNS - Linux-specific risky operations
-# =============================================================================
 
 [ask.network_config]
 description = "Linux network configuration (persistent changes)"
@@ -54,10 +46,6 @@ patterns = [
     "^chcon ",
     "^restorecon",
 ]
-
-# =============================================================================
-# ALLOW PATTERNS - Linux-specific safe operations
-# =============================================================================
 
 [allow.systemd_analysis]
 description = "systemd analysis and debugging (read-only)"
@@ -113,13 +101,10 @@ patterns = [
 [allow.linux_network_readonly]
 description = "Linux network inspection (read-only queries)"
 patterns = [
-    # nmcli show/status queries (mutations are in ask.network_config)
     "^nmcli .*(show|status|list)",
     "^nmcli -[tgf]",
-    # Display server inspection
     "^xrandr",
     "^xdpyinfo",
-    # Window manager inspection
     "^wmctrl -l",
     "^wmctrl -d",
 ]

--- a/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml
@@ -1,4 +1,4 @@
-# Bash command validation patterns for Claude Code PreToolUse hook
+# Bash command validation patterns for provider-neutral CLI hook adapters
 # Patterns are regular expressions matched against commands
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
@@ -398,7 +398,7 @@ description = "File removal targeting absolute system paths (outside /tmp and cu
 # Ask when rm targets absolute paths that are NOT:
 #   /tmp/ or /var/tmp/  — temp files (covered by allow.temp_cleanup)
 #   current git repo    — injected dynamically at runtime by _inject_git_root_patterns()
-#                         when Claude is opened inside a git project (cwd has .git)
+#                         when the CLI is opened inside a git project (cwd has .git)
 # Relative-path rm is allowed by allow.file_deletion_relative.
 # Catastrophic rm (/, ~, *, .) is blocked by deny.catastrophic_deletion.
 patterns = [
@@ -538,17 +538,10 @@ patterns = [
     "^let ",
     "^getopts ",
     # ^builtin with negative lookahead: block commands that have ask/deny guards.
-    # Without this, 'builtin eval dangerous' would skip ask.code_execution's eval guard
-    # because deny->ask->allow order means allow matches after ask misses (^eval pattern
-    # won't fire on 'builtin eval ...'). The lookahead re-blocks the dangerous forms.
     "^builtin (?!eval|exec|source|mapfile)\\S",
     "^hash ",
     "^hash$",
     # Control flow keywords - only bare keywords are auto-allowed.
-    # Full constructs (e.g., 'if condition; then cmd; fi') are split by
-    # the validator, and the body commands are validated separately.
-    # NOTE: Patterns with trailing space removed to prevent bypass like
-    # 'then rm -rf /tmp/*' matching '^then '.
     "^for ",
     "^while ",
     "^until ",
@@ -604,8 +597,6 @@ patterns = [
     "^bat",
     "^watch ",
     "^man ",
-    # Match --version/--help at end of command OR before a space/pipe suffix
-    # (e.g. 'bash --version | head -1' needs \s variant, not just $)
     "--version(\\s|$)",
     "--help(\\s|$)",
 ]
@@ -808,8 +799,6 @@ patterns = [
 
 [allow.system_user_info]
 description = "User session and power profile queries (read-only)"
-# Common informational commands that appear in diagnostic sessions
-# but have no side effects and are not covered by existing allow lists.
 patterns = [
     "^who\\b",
     "^last\\b",
@@ -818,10 +807,6 @@ patterns = [
 
 [allow.generic_read_subcommands]
 description = "Any tool using universally read-only subcommand verbs"
-# Covers unknown/new CLI tools that follow '<tool> <verb>' conventions.
-# 'show', 'get', 'inspect', 'export', 'dump' are intentionally excluded:
-# they expose secrets in specific tools (e.g. git show, kubectl get secret -o yaml).
-# These are legitimate dev operations but feel wrong to auto-approve silently.
 patterns = [
     "^[a-z][a-z0-9_-]+ (list|ls)( |$)",
     "^[a-z][a-z0-9_-]+ status( |$)",
@@ -832,10 +817,7 @@ patterns = [
 
 [allow.gsd_framework]
 description = "Get-Shit-Done (GSD) framework commands"
-# GSD runs node commands via gsd-tools.cjs for workstream management,
-# planning, and git operations on .planning/ directories.
 patterns = [
-    # GSD tools CLI (matched anywhere in segment after env-var stripping)
     "gsd-tools\\.cjs",
 ]
 
@@ -848,7 +830,6 @@ patterns = [
     "^parallel",
     "^chronic",
     "^sponge",
-    # Poetry runner
     "^poetrun run ",
 ]
 
@@ -869,20 +850,11 @@ description = "Git and GitHub CLI"
 patterns = [
     "^git ",
     "^gh ",
-    # cd <dir> && git <op>: common pattern for running git in a specific directory.
-    # The validator's split logic already handles this (each segment is validated
-    # independently), so this entry matches the full compound before splitting
-    # as an explicit documentation and fallback.
-    # Positive list of safe verbs: excludes force-push, hard-reset, etc. so
-    # ask.git_destructive is not bypassed if this ever matches as a full compound.
     "^cd .+ && git (add|status|diff|log|show|fetch|pull|checkout|switch|branch|commit|remote|tag|submodule|stash)( |$)",
 ]
 
 [allow.github_lifecycle]
 description = "GitHub CLI lifecycle operations that are reversible or purely additive"
-# gh issue close/reopen: trivially reversible (reopen restores the issue)
-# gh issue comment / gh pr comment: additive only, never destroys data
-# Note: gh pr merge, gh pr close, gh repo delete remain in ask.github_mutations
 patterns = [
     "^gh issue close",
     "^gh issue reopen",
@@ -1061,16 +1033,12 @@ patterns = [
 [allow.local_scripts]
 description = "Local project test and utility scripts"
 patterns = [
-    # Test scripts in tests/ directory
     "^\\./tests/",
     "^tests/",
-    # Utility scripts in scripts/ directory
     "^\\./scripts/",
     "^scripts/",
-    # Common script patterns
     "^\\./bin/",
     "^bin/",
-    # Shell interpreter + known safe directories (e.g. bash scripts/foo.sh)
     "^(bash|sh|zsh) tests/",
     "^(bash|sh|zsh) scripts/",
     "^(bash|sh|zsh) bin/",
@@ -1097,9 +1065,7 @@ patterns = [
     "^ansible ",
     "^vagrant",
     "^packer",
-    # Supabase
     "^supabase",
-    # Firecrawl (read-only scraping/search CLI)
     "^firecrawl",
 ]
 
@@ -1167,9 +1133,6 @@ patterns = [
 
 [allow.find_exec_readonly]
 description = "find -exec continuation segments with read-only commands"
-# When 'find ... -exec cmd {} \; -exec cmd2 {} \;' is split on ';', the second
-# and subsequent -exec clauses become orphaned segments starting with '-exec'.
-# These are safe to allow when the command is a read-only viewer.
 patterns = [
     "^-exec\\s+(cat|echo|head|tail|grep|wc|stat|file|ls|print|printf)\\s",
 ]
@@ -1247,11 +1210,7 @@ patterns = [
 
 [allow.kubernetes]
 description = "Kubernetes (mutations blocked by ask patterns)"
-# NOTE: kubectl exec is excluded here - it's handled by allow.kubernetes_exec_readonly
-# for read-only commands, and falls through to ask for everything else
 patterns = [
-    # Negative lookahead to exclude 'exec' subcommand, with \S to ensure
-    # we check after consuming ALL whitespace (prevents double-space bypass)
     "^kubectl\\s+(?!exec\\b)\\S",
     "^k3s kubectl\\s+(?!exec\\b)\\S",
     "^k9s",
@@ -1266,22 +1225,16 @@ patterns = [
 
 [allow.kubernetes_exec_readonly]
 description = "kubectl exec with read-only commands (other exec falls through to ask)"
-# NOTE: Only truly read-only commands are allowed here. Commands that can execute
-# arbitrary code (env with args, awk, sed, find) are excluded for security.
 patterns = [
-    # Read file contents
     "^kubectl exec .* -- cat ",
     "^kubectl exec .* -- head ",
     "^kubectl exec .* -- tail ",
     "^kubectl exec .* -- less ",
     "^kubectl exec .* -- more ",
-    # List/inspect files (note: find excluded due to -exec capability)
     "^kubectl exec .* -- ls",
     "^kubectl exec .* -- stat ",
     "^kubectl exec .* -- file ",
     "^kubectl exec .* -- wc ",
-    # Environment and process info
-    # NOTE: Only bare 'env' allowed - 'env VAR=x cmd' can run arbitrary commands
     "^kubectl exec .* -- env$",
     "^kubectl exec .* -- printenv",
     "^kubectl exec .* -- ps ",
@@ -1293,19 +1246,15 @@ patterns = [
     "^kubectl exec .* -- pwd$",
     "^kubectl exec .* -- hostname",
     "^kubectl exec .* -- uname",
-    # Search (note: awk/sed excluded - can execute commands or modify files)
     "^kubectl exec .* -- grep ",
-    # Disk/network info (note: ip excluded - can modify network config)
     "^kubectl exec .* -- df ",
     "^kubectl exec .* -- df$",
     "^kubectl exec .* -- du ",
     "^kubectl exec .* -- free",
     "^kubectl exec .* -- netstat",
     "^kubectl exec .* -- ss ",
-    # Date/time
     "^kubectl exec .* -- date",
     "^kubectl exec .* -- uptime",
-    # Same patterns for k3s (only safe commands)
     "^k3s kubectl exec .* -- cat ",
     "^k3s kubectl exec .* -- ls",
     "^k3s kubectl exec .* -- env$",
@@ -1317,20 +1266,12 @@ patterns = [
 
 [allow.kubernetes_exec_database]
 description = "kubectl exec database CLI tools (mutations blocked by ask.kubectl_exec_db_mutations)"
-# NOTE: Destructive SQL (DROP, DELETE, INSERT, etc.) is caught by
-# ask.kubectl_exec_db_mutations which is evaluated BEFORE these allow patterns.
-# What remains are read-only queries (SELECT, \d, \dt, etc.) and
-# psql meta-commands which are safe to auto-approve.
 patterns = [
-    # Direct psql (any flags like -U, -d, -c, -t, -tc, etc.)
     "^kubectl exec .* -- psql ",
     "^kubectl exec .* -- psql$",
-    # psql with env prefix (PGPASSWORD=...)
     "^kubectl exec .* -- env .* psql",
-    # Direct mysql
     "^kubectl exec .* -- mysql ",
     "^kubectl exec .* -- mysql$",
-    # Same for k3s
     "^k3s kubectl exec .* -- psql ",
     "^k3s kubectl exec .* -- env .* psql",
     "^k3s kubectl exec .* -- mysql ",
@@ -1338,28 +1279,12 @@ patterns = [
 
 [allow.kubernetes_exec_shell_commands]
 description = "kubectl exec with bash -c wrappers and common read-only inner commands"
-# The bash -c wrapper is the standard Kubernetes pattern for setting env vars
-# (e.g. PGPASSWORD) before invoking a database client.
-# Safety: ask.kubectl_exec_db_mutations (evaluated before allow patterns) catches
-# destructive SQL (DROP, DELETE, INSERT, etc.) even through bash -c wrappers,
-# since its patterns use .* to match across the 'bash -c' prefix.
-# ask.dangerous_pipelines catches 'find.*-exec.*rm' and 'find.*-delete' patterns.
-# Only non-destructive operations reach these allow patterns.
 patterns = [
-    # bash -c wrapping psql with env var prefix (e.g. PGPASSWORD=$(kubectl get secret ...))
     "kubectl exec .* -- bash -c '.*psql",
     "kubectl exec .* -- bash -c \".*psql",
-    # HTTP health checks and API endpoint inspection inside pods.
-    # Tradeoff: curl with -o/--output can write to arbitrary paths inside the pod.
-    # This is accepted because: (a) blast radius is pod-local, (b) the primary use
-    # case is health checks (curl http://localhost:8080/healthz) which far outweigh
-    # the file-write risk. Future: consider asking if '-o ' or '--output ' is present.
     "kubectl exec .* -- wget ",
     "kubectl exec .* -- curl ",
-    # File search inside pods (find.*-exec.*rm, find.*-exec.*mv, find.*-delete
-    # are caught by ask.dangerous_pipelines which is evaluated before allow patterns)
     "kubectl exec .* -- find ",
-    # k3s variants (same tradeoffs apply as kubectl above)
     "k3s kubectl exec .* -- bash -c '.*psql",
     "k3s kubectl exec .* -- bash -c \".*psql",
     "k3s kubectl exec .* -- wget ",
@@ -1392,16 +1317,11 @@ description = "Virtual environment binaries"
 patterns = [
     "^\\.venv/bin/",
     "^venv/bin/",
-    # Absolute paths to .venv/bin/ (worktree agents use absolute paths)
     "/\\.venv/bin/",
     "/venv/bin/",
-    # Poetry virtualenvs (common path: ~/.cache/pypoetry/virtualenvs/*/bin/)
     "pypoetry/virtualenvs/.*/bin/",
-    # Conda environments
     "conda.*/envs/.*/bin/",
-    # pipx
     "pipx/venvs/.*/bin/",
-    # Temporary venvs in /tmp (e.g. /tmp/test-venv/bin/pip, /tmp/test-venv/bin/pytest)
     "^/tmp/[^/]+/bin/",
 ]
 
@@ -1420,16 +1340,13 @@ patterns = [
     "^crontab -l",
     "^service .* status",
     "^getent ",
-    # locale: add word boundary to avoid matching localectl
     "^locale(\\s|$)",
-    # timedatectl: only read-only subcommands
     "^timedatectl$",
     "^timedatectl status",
     "^timedatectl timesync-status",
     "^timedatectl show-timesync",
     "^timedatectl show$",
     "^timedatectl show ",
-    # loginctl: only read-only subcommands
     "^loginctl list-sessions",
     "^loginctl session-status",
     "^loginctl list-users",
@@ -1443,7 +1360,6 @@ patterns = [
 [allow.terminal_multiplexers]
 description = "Terminal multiplexer read-only operations"
 patterns = [
-    # tmux read-only commands - list/show/display
     "^tmux ls$",
     "^tmux ls ",
     "^tmux list-",
@@ -1454,7 +1370,6 @@ patterns = [
     "^tmux info",
     "^tmux server-info",
     "^tmux wait-for",
-    # screen read-only commands
     "^screen -ls",
     "^screen -list",
     "^screen -wipe",
@@ -1530,21 +1445,10 @@ patterns = [
 
 [allow.file_deletion_relative]
 description = "File removal on relative paths (project files, build artifacts)"
-# Safe because: relative paths are within the project directory.
-# Catastrophic patterns (/, ~, *, .) are caught by deny.catastrophic_deletion
-# which runs BEFORE this allow pattern.
-# $ is excluded from the first-char class to prevent 'rm -rf $HOME' from being auto-approved.
 patterns = [
-    # rm with any flags + relative path (not starting with /, ~, or $)
     "^rm\\s+(-[a-zA-Z]+\\s+)*[^-/~$\\s]",
-    # rm with any flags + explicit ./ prefix
     "^rm\\s+(-[a-zA-Z]+\\s+)*\\./",
 ]
-
-# allow.project_file_deletion was removed: project file deletion is now handled
-# dynamically at runtime via _inject_git_root_patterns() in validate-bash.py.
-# When Claude is invoked inside a git repo (cwd/.git exists), rm on any path
-# under that repo root is auto-approved and the .git directory is protected.
 
 [allow.temp_cleanup]
 description = "Temp file cleanup"
@@ -1567,18 +1471,14 @@ patterns = [
     "^wl-copy",
     "^wl-paste",
     "^xdg-open ",
-    # Restrict open to URLs only; bare 'open -a Terminal' or 'open malware.app' would prompt
     "^open\\s+https?://",
 ]
 
 [allow.file_truncate]
 description = "File truncation on relative paths, /tmp, and /var/tmp"
 patterns = [
-    # truncate with flags + relative path (not starting with /, ~, or $)
     "^truncate\\s+(-[a-zA-Z]+\\s+)*[^-/~$\\s]",
-    # truncate with flags + explicit ./ prefix
     "^truncate\\s+(-[a-zA-Z]+\\s+)*\\./",
-    # truncate on /tmp/ and /var/tmp/ (log files, test fixtures)
     "^truncate\\s+(-[a-zA-Z]+\\s+)*/tmp/",
     "^truncate\\s+(-[a-zA-Z]+\\s+)*/var/tmp/",
 ]
@@ -1596,32 +1496,21 @@ patterns = [
 
 [allow.node_modules_bin]
 description = "Local node_modules/.bin executables (project-local dev tools)"
-# These are the same tools as npx/vitest/tsc/eslint but invoked directly
-# via node_modules/.bin/ path (relative or absolute). Safe because they
-# run project-local versions, same as the already-allowed bare commands.
 patterns = [
     "^node_modules/\\.bin/",
     "^\\./node_modules/\\.bin/",
-    # Absolute paths to node_modules/.bin/ (e.g. /home/user/project/node_modules/.bin/tsc)
     "^/[\\w./-]+/node_modules/\\.bin/",
 ]
 
 [allow.project_executables]
 description = "Running project executables from relative paths"
-# Executables in the current directory or subdirectories. These are
-# project-local binaries (compiled Go, Rust, etc.) that are safe to run.
 patterns = [
     "^\\./[\\w.-]+",
-    # Relative path executables (e.g. server/myapp, bin/tool)
-    # First component must start with a word char (not . or -) to prevent
-    # path traversal like ../../bin/cmd from being auto-allowed.
     "^[\\w][\\w.-]*/[\\w.-]+",
 ]
 
 [allow.find_readonly]
 description = "find with read-only actions (grep, cat, ls, wc, file, stat)"
-# find -exec with read-only commands is safe. The dangerous_pipelines ask
-# pattern only catches find -exec rm/mv/chmod/delete.
 patterns = [
     "^find .+ -exec (grep|cat|ls|wc|file|stat|head|tail|basename|dirname|sha256sum|md5sum|cksum)\\b",
     "^find .+ -print",
@@ -1629,17 +1518,12 @@ patterns = [
 
 [allow.xargs_readonly]
 description = "xargs with read-only commands (grep, cat, ls, wc, basename)"
-# xargs piping to read-only commands is safe. The dangerous_pipelines ask
-# pattern only catches xargs rm/mv/chmod/chown.
 patterns = [
     "xargs (grep|cat|ls|wc|file|stat|head|tail|basename|dirname|sha256sum|md5sum|cksum)\\b",
 ]
 
 [allow.git_merge_local]
 description = "Git merge of local branches (not squash or strategy overrides)"
-# Local branch merges are standard workflow and locally reversible.
-# Squash merges and strategy overrides (-X theirs/ours) remain in ask.
-# origin/ merges are already excluded from ask via negative lookahead.
 patterns = [
     "^git merge --ff-only\\b",
     "^git merge --no-edit\\b",
@@ -1660,9 +1544,6 @@ patterns = [
 
 [allow.git_force_with_lease]
 description = "Git push with --force-with-lease (safe force push)"
-# --force-with-lease is the safe alternative to --force: it refuses to
-# overwrite remote commits that aren't in the local ref, preventing
-# accidental data loss from concurrent pushes.
 patterns = [
     "^git push --force-with-lease\\b",
 ]
@@ -1675,11 +1556,6 @@ patterns = [
 
 [allow.npm_install_local]
 description = "npm install from package.json (no registry package specified)"
-# Bare 'npm install' (with no package name) installs from local package.json.
-# This is a routine dev operation with no supply-chain risk.
-# The ask.package_manager_install pattern uses a positive lookahead to only
-# catch 'npm install <pkg>', but 'npm install 2>&1' still matches because
-# '2>&1' looks like a package name. This pattern explicitly allows it.
 patterns = [
     "^npm install\\s*$",
     "^npm install\\s+2>",
@@ -1700,8 +1576,6 @@ patterns = [
 
 [allow.bash_project_scripts]
 description = "Running project scripts via bash/sh with absolute paths"
-# Covers: bash /home/user/project/scripts/foo.sh
-# The allow.local_scripts section already covers relative paths.
 patterns = [
     "^(bash|sh|zsh) /[\\w./-]+/scripts/",
     "^(bash|sh|zsh) /[\\w./-]+/tests/",

--- a/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.windows.toml
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.windows.toml
@@ -3,14 +3,6 @@
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
-#
-# These patterns cover Windows commands invoked from Git Bash, MSYS2, or Cygwin.
-# NOTE: WSL reports sys.platform as 'linux', so WSL users get Linux patterns.
-# Native PowerShell validation is out of scope (the hook is a Bash script).
-
-# =============================================================================
-# DENY PATTERNS - Windows-specific catastrophic operations
-# =============================================================================
 
 [deny.windows_destructive]
 description = "Windows destructive system commands"
@@ -20,10 +12,6 @@ patterns = [
     "^powershell.*Remove-Item.*-Recurse.*C:\\\\Windows",
     "^reg delete.*HKLM",
 ]
-
-# =============================================================================
-# ASK PATTERNS - Windows-specific risky operations
-# =============================================================================
 
 [ask.windows_service_management]
 description = "Windows service management"
@@ -56,10 +44,6 @@ patterns = [
     "^msiexec ",
     "^nuget install",
 ]
-
-# =============================================================================
-# ALLOW PATTERNS - Windows-specific safe operations
-# =============================================================================
 
 [allow.windows_system_info]
 description = "Windows system information (read-only)"

--- a/.ai-dev-foundry/shared/hooks/bash-policy/hook-lib.sh
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/hook-lib.sh
@@ -65,20 +65,24 @@ else:
 aidf_extract_project_from_json_input() {
     local input="$1"
     printf '%s' "$input" | python3 -c '
-import json, sys
+import json, os, sys
 try:
     data = json.load(sys.stdin)
-    cwd = data.get("cwd", "")
+    cwd = (
+        data.get("cwd", "")
+        or data.get("tool_input", {}).get("directory", "")
+        or data.get("toolInput", {}).get("directory", "")
+    )
     if not cwd:
-        cwd = data.get("tool_input", {}).get("directory", "")
-    if not cwd:
-        cwd = data.get("toolInput", {}).get("directory", "")
-    print(cwd or "unknown")
+        print("unknown")
+    elif "/.claude/worktrees/" in cwd:
+        before, after = cwd.split("/.claude/worktrees/", 1)
+        print(os.path.basename(before) + "-" + after.split("/", 1)[0])
+    else:
+        print(os.path.basename(cwd))
 except Exception:
     print("unknown")
-' 2>/dev/null | while IFS= read -r cwd; do
-    aidf_extract_project_from_cwd "$cwd"
-done
+' 2>/dev/null
 }
 
 aidf_extract_project_from_claude_input() {

--- a/.ai-dev-foundry/shared/hooks/bash-policy/hook-lib.sh
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/hook-lib.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Shared shell helpers for AI Dev Foundry hook adapters.
+#
+# Source: https://github.com/amulya-labs/ai-dev-foundry
+# License: MIT (https://opensource.org/licenses/MIT)
+
+AIDF_HOOK_LOG_DIR="${AIDF_HOOK_LOG_DIR:-/tmp/ai-dev-foundry-hook-logs}"
+AIDF_HOOK_LOG_RETENTION_DAYS="${AIDF_HOOK_LOG_RETENTION_DAYS:-15}"
+AIDF_HOOK_CLEANUP_INTERVAL_SECONDS="${AIDF_HOOK_CLEANUP_INTERVAL_SECONDS:-86400}"
+
+aidf_init_log_dir() {
+    local old_umask
+    old_umask=$(umask)
+    umask 077
+    mkdir -p "$AIDF_HOOK_LOG_DIR" 2>/dev/null
+    umask "$old_umask"
+
+    if [[ -L "$AIDF_HOOK_LOG_DIR" ]] || [[ ! -d "$AIDF_HOOK_LOG_DIR" ]] || [[ ! -O "$AIDF_HOOK_LOG_DIR" ]]; then
+        AIDF_HOOK_LOG_DIR=""
+        return 0
+    fi
+}
+
+aidf_cleanup_old_logs() {
+    [[ -z "$AIDF_HOOK_LOG_DIR" ]] && return 0
+
+    local cleanup_state_file now last_run
+    cleanup_state_file="$AIDF_HOOK_LOG_DIR/.last_cleanup"
+    now=$(date +%s)
+    if [[ -f "$cleanup_state_file" ]]; then
+        last_run=$(cat "$cleanup_state_file" 2>/dev/null || echo 0)
+    else
+        last_run=0
+    fi
+
+    if (( now - last_run < AIDF_HOOK_CLEANUP_INTERVAL_SECONDS )); then
+        return 0
+    fi
+
+    find "$AIDF_HOOK_LOG_DIR" -name "*.log" -type f -mtime +"$AIDF_HOOK_LOG_RETENTION_DAYS" -delete 2>/dev/null || true
+    echo "$now" > "$cleanup_state_file" 2>/dev/null || true
+}
+
+aidf_sanitize_for_log() {
+    printf '%s' "$1" | tr '\n\r\t' ' ' | tr -d '\000-\011\013-\037'
+}
+
+aidf_extract_project_from_cwd() {
+    local cwd="$1"
+    python3 -c '
+import os, sys
+cwd = sys.argv[1]
+if not cwd:
+    print("unknown")
+elif "/.claude/worktrees/" in cwd:
+    before, after = cwd.split("/.claude/worktrees/", 1)
+    project = os.path.basename(before)
+    agent = after.split("/")[0]
+    print(f"{project}-{agent}")
+else:
+    print(os.path.basename(cwd))
+' "$cwd" 2>/dev/null
+}
+
+aidf_extract_project_from_json_input() {
+    local input="$1"
+    printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    cwd = data.get("cwd", "")
+    if not cwd:
+        cwd = data.get("tool_input", {}).get("directory", "")
+    if not cwd:
+        cwd = data.get("toolInput", {}).get("directory", "")
+    print(cwd or "unknown")
+except Exception:
+    print("unknown")
+' 2>/dev/null | while IFS= read -r cwd; do
+    aidf_extract_project_from_cwd "$cwd"
+done
+}
+
+aidf_extract_project_from_claude_input() {
+    aidf_extract_project_from_json_input "$1"
+}
+
+aidf_log_file_for_project() {
+    local project="$1"
+    [[ -z "$AIDF_HOOK_LOG_DIR" ]] && return 0
+    printf '%s/%s-%s.log' "$AIDF_HOOK_LOG_DIR" "$(LC_ALL=C date '+%Y-%m-%d-%a')" "$project"
+}

--- a/.ai-dev-foundry/shared/hooks/bash-policy/validate-command.py
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/validate-command.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""
+Bash command validator with a provider-neutral JSON contract.
+Reads patterns from TOML config and validates commands.
+
+Source: https://github.com/amulya-labs/ai-dev-foundry
+License: MIT (https://opensource.org/licenses/MIT)
+"""
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+# Python 3.11+ has tomllib built-in
+try:
+    import tomllib
+except ImportError:
+    # Fallback for Python < 3.11
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print(
+            "Error: Python 3.11+ required, or install 'tomli' package for older versions",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+@dataclass
+class CompiledPattern:
+    """A pre-compiled regex pattern with metadata."""
+
+    regex: re.Pattern
+    section: str
+    original: str
+
+
+def load_config(config_path: str) -> dict:
+    """Load and validate TOML configuration."""
+    try:
+        with open(config_path, "rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        print(f"Error: Invalid TOML in {config_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print(f"Error: Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def detect_os() -> str:
+    """Detect OS platform and return the suffix for OS-specific config files."""
+    platform = sys.platform
+    if platform.startswith("linux"):
+        return "linux"
+    elif platform == "darwin":
+        return "darwin"
+    elif platform in ("win32", "cygwin", "msys"):
+        return "windows"
+    return platform
+
+
+def merge_os_config(base: dict, overlay: dict) -> dict:
+    """Merge OS-specific config into base config with additive-append semantics."""
+    for category in ("deny", "ask", "allow"):
+        overlay_sections = overlay.get(category, {})
+        if not overlay_sections:
+            continue
+        base.setdefault(category, {})
+        for section_name, section_data in overlay_sections.items():
+            if not isinstance(section_data, dict) or "patterns" not in section_data:
+                continue
+            if section_name in base[category] and isinstance(base[category][section_name], dict):
+                base[category][section_name]["patterns"] = (
+                    base[category][section_name].get("patterns", []) + section_data["patterns"]
+                )
+            else:
+                base[category][section_name] = section_data
+    return base
+
+
+def compile_patterns(config: dict, category: str) -> list[CompiledPattern]:
+    """Extract and compile patterns for a category (deny/ask/allow)."""
+    compiled = []
+    for section_name, section in config.get(category, {}).items():
+        if isinstance(section, dict) and "patterns" in section:
+            for pattern in section["patterns"]:
+                try:
+                    regex = re.compile(pattern)
+                    compiled.append(
+                        CompiledPattern(regex=regex, section=f"{category}.{section_name}", original=pattern)
+                    )
+                except re.error as e:
+                    print(
+                        f"Warning: Invalid regex '{pattern}' in {category}.{section_name}: {e}",
+                        file=sys.stderr,
+                    )
+    return compiled
+
+
+def strip_env_vars(cmd: str) -> str:
+    """Strip environment variable assignments from command start."""
+    while True:
+        cmd = cmd.lstrip()
+        match = re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", cmd)
+        if not match:
+            break
+
+        rest = cmd[match.end() :]
+
+        if rest.startswith("$("):
+            depth = 1
+            i = 2
+            while depth > 0 and i < len(rest):
+                if rest[i] == "(":
+                    depth += 1
+                elif rest[i] == ")":
+                    depth -= 1
+                i += 1
+            cmd = rest[i:]
+        elif rest.startswith("`"):
+            end = rest.find("`", 1)
+            cmd = rest[end + 1 :] if end > 0 else ""
+        elif rest.startswith('"'):
+            i = 1
+            while i < len(rest):
+                if rest[i] == "\\" and i + 1 < len(rest):
+                    i += 2
+                    continue
+                if rest[i] == '"':
+                    break
+                i += 1
+            cmd = rest[i + 1 :]
+        elif rest.startswith("'"):
+            end = rest.find("'", 1)
+            cmd = rest[end + 1 :] if end > 0 else ""
+        elif rest.startswith("$") and len(rest) > 1 and re.match(r"[A-Za-z_]", rest[1]):
+            var_match = re.match(r"^\$[A-Za-z_][A-Za-z0-9_]*", rest)
+            cmd = rest[var_match.end() :] if var_match else rest
+        else:
+            val_match = re.match(r"^[^\s]*\s*", rest)
+            cmd = rest[val_match.end() :] if val_match else ""
+
+    return cmd.lstrip()
+
+
+def strip_leading_comment(cmd: str) -> str:
+    """Strip shell comments from the start of a command."""
+    lines = cmd.split("\n")
+    while lines and lines[0].strip().startswith("#"):
+        lines.pop(0)
+    return "\n".join(lines).lstrip()
+
+
+def _find_matching_paren(cmd: str, start: int) -> int:
+    """Find the matching ')' for a '(' that was just consumed."""
+    depth = 1
+    i = start
+    inner_quote = None
+    heredoc_delim = None
+
+    while i < len(cmd) and depth > 0:
+        char = cmd[i]
+
+        if heredoc_delim is not None:
+            if char == "\n":
+                next_nl = cmd.find("\n", i + 1)
+                if next_nl == -1:
+                    next_nl = len(cmd)
+                raw_line = cmd[i + 1 : next_nl]
+                if raw_line == heredoc_delim:
+                    i = next_nl
+                    heredoc_delim = None
+                    continue
+            i += 1
+            continue
+
+        if char == "\\" and i + 1 < len(cmd) and inner_quote != "'":
+            i += 2
+            continue
+
+        if char in ('"', "'"):
+            if inner_quote is None:
+                inner_quote = char
+            elif inner_quote == char:
+                inner_quote = None
+        elif inner_quote is None:
+            if char == "<" and cmd[i : i + 2] == "<<" and (i + 2 >= len(cmd) or cmd[i + 2] != "<"):
+                delim, _strip, end_pos = _parse_heredoc_delim(cmd, i + 2)
+                if delim:
+                    i = end_pos
+                    heredoc_delim = delim
+                    continue
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+
+        i += 1
+
+    return i
+
+
+def _parse_heredoc_delim(cmd: str, pos: int) -> tuple:
+    """Parse a heredoc delimiter starting after '<<'."""
+    j = pos
+    strip_tabs = False
+    if j < len(cmd) and cmd[j] == "-":
+        strip_tabs = True
+        j += 1
+    while j < len(cmd) and cmd[j] in " \t":
+        j += 1
+    if j >= len(cmd) or cmd[j] == "\n":
+        return None, False, pos
+
+    if cmd[j] in ("'", '"'):
+        delim_quote = cmd[j]
+        k = cmd.find(delim_quote, j + 1)
+        if k > j + 1:
+            return cmd[j + 1 : k], strip_tabs, k + 1
+        return None, False, pos
+    else:
+        m = re.match(r"[A-Za-z_][A-Za-z0-9_]*", cmd[j:])
+        if m:
+            return m.group(0), strip_tabs, j + m.end()
+        return None, False, pos
+
+
+def split_commands(cmd: str) -> list[str]:
+    """Split command on &&, ||, ;, newlines while respecting shell syntax."""
+    segments = []
+    current = ""
+    quote = None
+    i = 0
+    heredoc_delim = None
+    heredoc_strip_tabs = False
+
+    while i < len(cmd):
+        char = cmd[i]
+
+        if heredoc_delim is not None:
+            current += char
+            if char == "\n":
+                next_nl = cmd.find("\n", i + 1)
+                if next_nl == -1:
+                    next_nl = len(cmd)
+                raw_line = cmd[i + 1 : next_nl]
+                candidate = raw_line.lstrip("\t") if heredoc_strip_tabs else raw_line
+                if candidate == heredoc_delim:
+                    current += raw_line
+                    i = next_nl
+                    heredoc_delim = None
+                    heredoc_strip_tabs = False
+                    continue
+            i += 1
+            continue
+
+        if char in ('"', "'"):
+            backslash_count = 0
+            j = i - 1
+            while j >= 0 and cmd[j] == "\\":
+                backslash_count += 1
+                j -= 1
+            if backslash_count % 2 == 0:
+                if quote is None:
+                    quote = char
+                elif quote == char:
+                    quote = None
+
+        if char == "$" and i + 1 < len(cmd) and cmd[i + 1] == "(" and quote != "'":
+            end = _find_matching_paren(cmd, i + 2)
+            current += cmd[i:end]
+            i = end
+            continue
+
+        if quote is None:
+            if char == "<" and cmd[i : i + 2] == "<<" and (i + 2 >= len(cmd) or cmd[i + 2] != "<"):
+                delim, strip_tabs, end_pos = _parse_heredoc_delim(cmd, i + 2)
+                if delim:
+                    current += cmd[i:end_pos]
+                    i = end_pos
+                    heredoc_delim = delim
+                    heredoc_strip_tabs = strip_tabs
+                    continue
+
+            if cmd[i : i + 2] in ("&&", "||"):
+                if current.strip():
+                    segments.append(current)
+                current = ""
+                i += 2
+                continue
+            elif char == ";":
+                if cmd[i : i + 2] == ";;":
+                    current += ";;"
+                    i += 2
+                    continue
+                if current.endswith("\\"):
+                    current += char
+                    i += 1
+                    continue
+                if current.strip():
+                    segments.append(current)
+                current = ""
+                i += 1
+                continue
+            elif char == "\n":
+                if current.endswith("\\"):
+                    current = current[:-1]
+                    i += 1
+                    continue
+                if current.strip():
+                    segments.append(current)
+                current = ""
+                i += 1
+                continue
+
+        current += char
+        i += 1
+
+    if current.strip():
+        segments.append(current)
+
+    return segments
+
+
+CONTROL_FLOW_KEYWORDS = re.compile(r"^(then|else|elif|do)\s+", re.IGNORECASE)
+CONTROL_FLOW_TERMINATORS = re.compile(r"^(done|fi|esac)(\s+[\d<>|&].*|\s*$)", re.IGNORECASE)
+
+
+def extract_assignments(segment: str) -> dict[str, str]:
+    """Extract VAR=literal assignments from a raw segment."""
+    env = {}
+    rest = segment.lstrip()
+    while True:
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=", rest)
+        if not match:
+            break
+
+        name = match.group(1)
+        rest = rest[match.end() :]
+
+        if rest.startswith("$(") or rest.startswith("`"):
+            break
+        elif rest.startswith("${"):
+            break
+        elif rest.startswith("$") and len(rest) > 1 and re.match(r"[A-Za-z_]", rest[1]):
+            break
+        elif rest.startswith('"'):
+            i = 1
+            while i < len(rest):
+                if rest[i] == "\\" and i + 1 < len(rest):
+                    i += 2
+                    continue
+                if rest[i] == '"':
+                    break
+                i += 1
+            else:
+                break
+            captured = rest[1:i]
+            if "$(" in captured or "`" in captured or "${" in captured:
+                break
+            env[name] = captured
+            rest = rest[i + 1 :]
+        elif rest.startswith("'"):
+            end = rest.find("'", 1)
+            if end > 0:
+                env[name] = rest[1:end]
+                rest = rest[end + 1 :]
+            else:
+                break
+        else:
+            val_match = re.match(r"^([^\s]*)", rest)
+            env[name] = val_match.group(1) if val_match else ""
+            rest = rest[val_match.end() :] if val_match else ""
+
+        rest = rest.lstrip()
+
+    return env
+
+
+def substitute_known_vars(segment: str, env: dict[str, str]) -> str:
+    """Replace $VAR or ${VAR} at position 0 of a cleaned segment with known values."""
+    if not segment.startswith("$"):
+        return segment
+
+    match = re.match(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}", segment)
+    if match:
+        name = match.group(1)
+        if name in env:
+            return env[name] + segment[match.end() :]
+        return segment
+
+    match = re.match(r"^\$([A-Za-z_][A-Za-z0-9_]*)", segment)
+    if match:
+        name = match.group(1)
+        if name in env:
+            return env[name] + segment[match.end() :]
+
+    return segment
+
+
+_SHELL_META = re.compile(r"&&|\|\||;|\||\$\(|`|\(|>>?|>&")
+
+
+def strip_bash_c_wrapper(segment: str) -> str:
+    """Unwrap simple bash -c / sh -c wrappers to expose the inner command."""
+    match = re.match(r"^(?:/bin/)?(bash|sh)\s+-c\s+([\'\"])(.*)\2\s*$", segment, re.DOTALL)
+    if not match:
+        return segment
+
+    delimiter = match.group(2)
+    inner = match.group(3)
+
+    if "\n" in inner or "\r" in inner:
+        return segment
+    if delimiter in inner:
+        return segment
+    if _SHELL_META.search(inner):
+        return segment
+
+    return inner
+
+
+def strip_control_flow_keyword(segment: str) -> str:
+    """Strip shell control flow keywords from segment start."""
+    if CONTROL_FLOW_TERMINATORS.match(segment):
+        return ""
+
+    match = CONTROL_FLOW_KEYWORDS.match(segment)
+    if match:
+        return segment[match.end() :].lstrip()
+
+    return segment
+
+
+def strip_line_continuations(cmd: str) -> str:
+    r"""Strip shell line continuations (\<newline>) from command."""
+    return cmd.replace("\\\n", " ")
+
+
+def _is_bare_redirect(segment: str) -> bool:
+    """Check if a segment is just a bare redirect/pipe tail with no real command."""
+    s = re.sub(r"\d*>>?&?\d*\s*/?[\w./-]*", "", segment)
+    s = re.sub(
+        r"\|\s*(head|tail|sort|wc|uniq|tee|grep|sed|awk|cut|tr|column|less|more|cat|fmt|nl|rev|paste|comm|fold|expand|unexpand|pr)\b[^|]*",
+        "",
+        s,
+    )
+    s = re.sub(r"\|", "", s)
+    return not s.strip()
+
+
+def _strip_case_label(segment: str) -> str:
+    """Strip case-statement pattern labels from segment start."""
+    match = re.match(r"^(\S+)\)\s+", segment)
+    if match and "$(" not in match.group(1) and "(" not in match.group(1):
+        return segment[match.end() :]
+    return segment
+
+
+def clean_segment(segment: str) -> str:
+    """Clean a command segment: strip whitespace, subshell chars, env vars, comments."""
+    segment = segment.strip()
+
+    while segment.startswith("\\") and (len(segment) == 1 or segment[1] in " \t\n"):
+        segment = segment[1:].lstrip()
+
+    segment = strip_leading_comment(segment)
+    segment = strip_env_vars(segment)
+    if not segment.strip():
+        return ""
+
+    while segment and segment[0] in "({":
+        segment = segment[1:].lstrip()
+    while segment and segment[-1] in ")}":
+        segment = segment[:-1].rstrip()
+
+    if _is_bare_redirect(segment):
+        return ""
+
+    segment = strip_bash_c_wrapper(segment)
+    segment = strip_control_flow_keyword(segment)
+    segment = _strip_case_label(segment)
+    segment = strip_env_vars(segment)
+    if not segment.strip():
+        return ""
+
+    return segment
+
+
+def check_patterns(segment: str, patterns: list[CompiledPattern]) -> tuple[bool, str]:
+    """Check if segment matches any compiled pattern."""
+    for pattern in patterns:
+        if pattern.regex.search(segment):
+            return True, pattern.section
+    return False, ""
+
+
+def validate_command(
+    command: str,
+    deny_patterns: list[CompiledPattern],
+    ask_patterns: list[CompiledPattern],
+    allow_patterns: list[CompiledPattern],
+) -> tuple[str, str]:
+    """Validate a command against patterns."""
+    command = strip_line_continuations(command)
+
+    matched, section = check_patterns(command, deny_patterns)
+    if matched:
+        return "deny", f"Blocked: '{command[:100]}' matches {section}"
+
+    segments = split_commands(command)
+    final_decision = "allow"
+    final_reason = "Command matches allow patterns"
+    env_context: dict[str, str] = {}
+
+    for segment in segments:
+        env_context.update(extract_assignments(segment))
+
+        cleaned = clean_segment(segment)
+        if not cleaned:
+            continue
+
+        cleaned = substitute_known_vars(cleaned, env_context)
+
+        matched, section = check_patterns(cleaned, deny_patterns)
+        if matched:
+            return "deny", f"Blocked: '{cleaned}' matches {section}"
+
+        matched, section = check_patterns(cleaned, ask_patterns)
+        if matched:
+            if final_decision != "ask":
+                final_decision = "ask"
+                final_reason = f"'{cleaned}' matches {section}"
+            continue
+
+        matched, _ = check_patterns(cleaned, allow_patterns)
+        if matched:
+            continue
+
+        if final_decision != "ask":
+            final_decision = "ask"
+            final_reason = f"'{cleaned}' not in auto-approve list"
+
+    return final_decision, final_reason
+
+
+def _add_to_negative_lookahead(pattern: str, exclusion: str) -> str:
+    """Prepend an exclusion alternative to the first negative lookahead in a pattern."""
+    if "(?!" not in pattern:
+        return pattern
+    return pattern.replace("(?!", f"(?!{exclusion}|", 1)
+
+
+def _inject_git_root_patterns(config: dict, git_root: str) -> None:
+    """Dynamically inject git root path into validation patterns."""
+    escaped_for_lookahead = re.escape(git_root.lstrip("/")) + "/"
+
+    ask_file_del = config.get("ask", {}).get("file_deletion", {})
+    if isinstance(ask_file_del, dict) and "patterns" in ask_file_del:
+        ask_file_del["patterns"] = [
+            _add_to_negative_lookahead(p, escaped_for_lookahead) for p in ask_file_del["patterns"]
+        ]
+
+    escaped_abs = re.escape(git_root)
+    config.setdefault("allow", {})["git_project_files"] = {
+        "description": f"File removal within git repository at {git_root}",
+        "patterns": [f"^rm\\s+(-[a-zA-Z]+\\s+)*{escaped_abs}/"],
+    }
+
+    escaped_git_dir = re.escape(os.path.join(git_root, ".git"))
+    config.setdefault("ask", {})["git_metadata_protection"] = {
+        "description": "Protect .git metadata directory from deletion",
+        "patterns": [f"^rm\\b.*{escaped_git_dir}(/|$)"],
+    }
+
+
+def load_runtime_config(config_path: str, cwd: str = "") -> dict:
+    """Load base config, merge OS overlay, and inject cwd-aware patterns."""
+    config = load_config(config_path)
+
+    os_suffix = detect_os()
+    config_dir = os.path.dirname(config_path)
+    config_base = os.path.splitext(os.path.basename(config_path))[0]
+    os_config_path = os.path.join(config_dir, f"{config_base}.{os_suffix}.toml")
+    if os.path.isfile(os_config_path):
+        os_config = load_config(os_config_path)
+        config = merge_os_config(config, os_config)
+
+    if cwd:
+        cwd = os.path.normpath(cwd)
+        if os.path.exists(os.path.join(cwd, ".git")):
+            _inject_git_root_patterns(config, cwd)
+
+    return config
+
+
+def evaluate_request(request: dict, config_path: str) -> tuple[str, str]:
+    """Evaluate a normalized request with fields like command and cwd."""
+    command = request.get("command", "")
+    if not command:
+        return "allow", "No command to validate"
+
+    config = load_runtime_config(config_path, request.get("cwd", ""))
+    deny_patterns = compile_patterns(config, "deny")
+    ask_patterns = compile_patterns(config, "ask")
+    allow_patterns = compile_patterns(config, "allow")
+    return validate_command(command, deny_patterns, ask_patterns, allow_patterns)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: validate-command.py <config.toml>", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        request = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    command = request.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    decision, reason = evaluate_request(request, sys.argv[1])
+    print(json.dumps({"decision": decision, "reason": reason}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.ai-dev-foundry/shared/hooks/bash-policy/validate-command.py
+++ b/.ai-dev-foundry/shared/hooks/bash-policy/validate-command.py
@@ -111,15 +111,8 @@ def strip_env_vars(cmd: str) -> str:
         rest = cmd[match.end() :]
 
         if rest.startswith("$("):
-            depth = 1
-            i = 2
-            while depth > 0 and i < len(rest):
-                if rest[i] == "(":
-                    depth += 1
-                elif rest[i] == ")":
-                    depth -= 1
-                i += 1
-            cmd = rest[i:]
+            end = _find_matching_paren(rest, 2)
+            cmd = rest[end:]
         elif rest.startswith("`"):
             end = rest.find("`", 1)
             cmd = rest[end + 1 :] if end > 0 else ""
@@ -406,7 +399,11 @@ _SHELL_META = re.compile(r"&&|\|\||;|\||\$\(|`|\(|>>?|>&")
 
 def strip_bash_c_wrapper(segment: str) -> str:
     """Unwrap simple bash -c / sh -c wrappers to expose the inner command."""
-    match = re.match(r"^(?:/bin/)?(bash|sh)\s+-c\s+([\'\"])(.*)\2\s*$", segment, re.DOTALL)
+    match = re.match(
+        r"^(?:/bin/)?(bash|sh)\s+(?:-[a-zA-Z]+\s+)*-c\s+([\'\"])(.*)\2\s*$",
+        segment,
+        re.DOTALL,
+    )
     if not match:
         return segment
 

--- a/.claude/hooks/validate-bash.py
+++ b/.claude/hooks/validate-bash.py
@@ -21,15 +21,6 @@ validate_command_core = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = validate_command_core
 _spec.loader.exec_module(validate_command_core)
 
-CompiledPattern = validate_command_core.CompiledPattern
-load_config = validate_command_core.load_config
-detect_os = validate_command_core.detect_os
-merge_os_config = validate_command_core.merge_os_config
-compile_patterns = validate_command_core.compile_patterns
-strip_line_continuations = validate_command_core.strip_line_continuations
-split_commands = validate_command_core.split_commands
-validate_command = validate_command_core.validate_command
-
 
 def output_decision(decision: str, reason: str) -> None:
     """Output JSON decision for Claude Code hook."""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/validate-bash.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/post-bash.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/post-bash.sh
+++ b/.codex/hooks/post-bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Code PostToolUse hook adapter for the shared Bash policy engine.
+# Codex PostToolUse hook adapter for the shared Bash policy engine.
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
@@ -15,12 +15,13 @@ aidf_init_log_dir
 [[ -z "$AIDF_HOOK_LOG_DIR" ]] && exit 0
 
 INPUT=$(cat)
-PROJECT=$(aidf_extract_project_from_claude_input "$INPUT")
+PROJECT=$(aidf_extract_project_from_json_input "$INPUT")
 COMMAND=$(printf '%s' "$INPUT" | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
-    print(data.get('tool_input', {}).get('command', '').replace('\n', '\\\\n'))
+    tool_input = data.get('tool_input') or data.get('toolInput') or {}
+    print((tool_input.get('command') or tool_input.get('commandLine') or '').replace('\n', '\\\\n'))
 except Exception:
     print('')
 " 2>/dev/null)

--- a/.codex/hooks/validate-bash.py
+++ b/.codex/hooks/validate-bash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Claude adapter for the provider-neutral Bash command validator.
+Codex adapter for the provider-neutral Bash command validator.
 
 Source: https://github.com/amulya-labs/ai-dev-foundry
 License: MIT (https://opensource.org/licenses/MIT)
@@ -21,18 +21,12 @@ validate_command_core = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = validate_command_core
 _spec.loader.exec_module(validate_command_core)
 
-CompiledPattern = validate_command_core.CompiledPattern
-load_config = validate_command_core.load_config
-detect_os = validate_command_core.detect_os
-merge_os_config = validate_command_core.merge_os_config
-compile_patterns = validate_command_core.compile_patterns
-strip_line_continuations = validate_command_core.strip_line_continuations
-split_commands = validate_command_core.split_commands
-validate_command = validate_command_core.validate_command
+
+def _read_tool_input(input_data: dict) -> dict:
+    return input_data.get("tool_input", {}) or input_data.get("toolInput", {})
 
 
 def output_decision(decision: str, reason: str) -> None:
-    """Output JSON decision for Claude Code hook."""
     print(
         json.dumps(
             {
@@ -58,12 +52,13 @@ def main() -> None:
     except json.JSONDecodeError:
         sys.exit(0)
 
+    tool_input = _read_tool_input(input_data)
     request = {
-        "provider": "claude",
+        "provider": "codex",
         "phase": "pre_tool_use",
         "tool": "bash",
-        "command": input_data.get("tool_input", {}).get("command", ""),
-        "cwd": input_data.get("cwd", ""),
+        "command": tool_input.get("command", "") or tool_input.get("commandLine", ""),
+        "cwd": input_data.get("cwd", "") or tool_input.get("directory", ""),
     }
 
     if not request["command"]:

--- a/.codex/hooks/validate-bash.sh
+++ b/.codex/hooks/validate-bash.sh
@@ -17,6 +17,16 @@ aidf_init_log_dir
 aidf_cleanup_old_logs
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
+    if [[ -n "$AIDF_HOOK_LOG_DIR" ]]; then
+        LOG_FILE="$AIDF_HOOK_LOG_DIR/$(LC_ALL=C date '+%Y-%m-%d')-error.log"
+        {
+            echo "========================================"
+            echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
+            echo "ERROR:  Configuration file not found"
+            echo "PATH:   $CONFIG_FILE"
+            echo "========================================"
+        } >> "$LOG_FILE"
+    fi
     echo "Error: Configuration file not found: $CONFIG_FILE" >&2
     exit 1
 fi

--- a/.codex/hooks/validate-bash.sh
+++ b/.codex/hooks/validate-bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Code PreToolUse hook adapter for the shared Bash policy engine.
+# Codex PreToolUse hook adapter for the shared Bash policy engine.
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
@@ -17,27 +17,17 @@ aidf_init_log_dir
 aidf_cleanup_old_logs
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
-    if [[ -n "$AIDF_HOOK_LOG_DIR" ]]; then
-        LOG_FILE="$AIDF_HOOK_LOG_DIR/$(LC_ALL=C date '+%Y-%m-%d')-error.log"
-        {
-            echo "========================================"
-            echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
-            echo "ERROR:  Configuration file not found"
-            echo "PATH:   $CONFIG_FILE"
-            echo "========================================"
-        } >> "$LOG_FILE"
-    fi
     echo "Error: Configuration file not found: $CONFIG_FILE" >&2
     exit 1
 fi
 
 INPUT=$(cat)
-PROJECT=$(aidf_extract_project_from_claude_input "$INPUT")
+PROJECT=$(aidf_extract_project_from_json_input "$INPUT")
 LOG_FILE="$(aidf_log_file_for_project "$PROJECT")"
 
 STDERR_FILE=$(mktemp)
 OUTPUT=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFIG_FILE" 2>"$STDERR_FILE") || {
-    COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command','<unknown>'))" 2>/dev/null || echo "<parse error>")
+    COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '<unknown>')" 2>/dev/null || echo "<parse error>")
     COMMAND=$(aidf_sanitize_for_log "$COMMAND")
     STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
     rm -f "$STDERR_FILE"
@@ -47,7 +37,6 @@ OUTPUT=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFIG_
             echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
             echo "ERROR:  Python script failed"
             echo "CMD:    $COMMAND"
-            echo "STDOUT: $OUTPUT"
             echo "STDERR: $STDERR_CONTENT"
             echo "========================================"
         } >> "$LOG_FILE"
@@ -58,7 +47,7 @@ rm -f "$STDERR_FILE"
 
 if [[ -n "$LOG_FILE" ]]; then
     if echo "$OUTPUT" | grep -q '"permissionDecision": *"deny"'; then
-        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '')" 2>/dev/null)
         REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hookSpecificOutput',{}).get('permissionDecisionReason',''))" 2>/dev/null)
         COMMAND=$(aidf_sanitize_for_log "$COMMAND")
         REASON=$(aidf_sanitize_for_log "$REASON")
@@ -71,7 +60,7 @@ if [[ -n "$LOG_FILE" ]]; then
             echo "========================================"
         } >> "$LOG_FILE"
     elif echo "$OUTPUT" | grep -q '"permissionDecision": *"ask"'; then
-        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '')" 2>/dev/null)
         REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hookSpecificOutput',{}).get('permissionDecisionReason',''))" 2>/dev/null)
         COMMAND=$(aidf_sanitize_for_log "$COMMAND")
         REASON=$(aidf_sanitize_for_log "$REASON")

--- a/.gemini/hooks/post-bash.sh
+++ b/.gemini/hooks/post-bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Code PostToolUse hook adapter for the shared Bash policy engine.
+# Gemini CLI AfterTool hook adapter for the shared Bash policy engine.
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
@@ -15,12 +15,13 @@ aidf_init_log_dir
 [[ -z "$AIDF_HOOK_LOG_DIR" ]] && exit 0
 
 INPUT=$(cat)
-PROJECT=$(aidf_extract_project_from_claude_input "$INPUT")
+PROJECT=$(aidf_extract_project_from_json_input "$INPUT")
 COMMAND=$(printf '%s' "$INPUT" | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
-    print(data.get('tool_input', {}).get('command', '').replace('\n', '\\\\n'))
+    tool_input = data.get('tool_input') or data.get('toolInput') or {}
+    print((tool_input.get('command') or tool_input.get('commandLine') or '').replace('\n', '\\\\n'))
 except Exception:
     print('')
 " 2>/dev/null)
@@ -32,7 +33,7 @@ DECISION=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFI
 import sys, json
 try:
     data = json.load(sys.stdin)
-    print(data.get('hookSpecificOutput', {}).get('permissionDecision', ''))
+    print(data.get('decision', ''))
 except Exception:
     print('')
 " 2>/dev/null)

--- a/.gemini/hooks/validate-bash.py
+++ b/.gemini/hooks/validate-bash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Claude adapter for the provider-neutral Bash command validator.
+Gemini CLI adapter for the provider-neutral Bash command validator.
 
 Source: https://github.com/amulya-labs/ai-dev-foundry
 License: MIT (https://opensource.org/licenses/MIT)
@@ -21,29 +21,13 @@ validate_command_core = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = validate_command_core
 _spec.loader.exec_module(validate_command_core)
 
-CompiledPattern = validate_command_core.CompiledPattern
-load_config = validate_command_core.load_config
-detect_os = validate_command_core.detect_os
-merge_os_config = validate_command_core.merge_os_config
-compile_patterns = validate_command_core.compile_patterns
-strip_line_continuations = validate_command_core.strip_line_continuations
-split_commands = validate_command_core.split_commands
-validate_command = validate_command_core.validate_command
+
+def _read_tool_input(input_data: dict) -> dict:
+    return input_data.get("tool_input", {}) or input_data.get("toolInput", {})
 
 
 def output_decision(decision: str, reason: str) -> None:
-    """Output JSON decision for Claude Code hook."""
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": decision,
-                    "permissionDecisionReason": reason,
-                }
-            }
-        )
-    )
+    print(json.dumps({"decision": decision, "reason": reason}))
 
 
 def main() -> None:
@@ -58,12 +42,13 @@ def main() -> None:
     except json.JSONDecodeError:
         sys.exit(0)
 
+    tool_input = _read_tool_input(input_data)
     request = {
-        "provider": "claude",
-        "phase": "pre_tool_use",
-        "tool": "bash",
-        "command": input_data.get("tool_input", {}).get("command", ""),
-        "cwd": input_data.get("cwd", ""),
+        "provider": "gemini",
+        "phase": "before_tool",
+        "tool": "run_shell_command",
+        "command": tool_input.get("command", "") or tool_input.get("commandLine", ""),
+        "cwd": input_data.get("cwd", "") or tool_input.get("directory", ""),
     }
 
     if not request["command"]:

--- a/.gemini/hooks/validate-bash.sh
+++ b/.gemini/hooks/validate-bash.sh
@@ -17,6 +17,16 @@ aidf_init_log_dir
 aidf_cleanup_old_logs
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
+    if [[ -n "$AIDF_HOOK_LOG_DIR" ]]; then
+        LOG_FILE="$AIDF_HOOK_LOG_DIR/$(LC_ALL=C date '+%Y-%m-%d')-error.log"
+        {
+            echo "========================================"
+            echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
+            echo "ERROR:  Configuration file not found"
+            echo "PATH:   $CONFIG_FILE"
+            echo "========================================"
+        } >> "$LOG_FILE"
+    fi
     echo "Error: Configuration file not found: $CONFIG_FILE" >&2
     exit 1
 fi

--- a/.gemini/hooks/validate-bash.sh
+++ b/.gemini/hooks/validate-bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Code PreToolUse hook adapter for the shared Bash policy engine.
+# Gemini CLI BeforeTool hook adapter for the shared Bash policy engine.
 #
 # Source: https://github.com/amulya-labs/ai-dev-foundry
 # License: MIT (https://opensource.org/licenses/MIT)
@@ -17,27 +17,17 @@ aidf_init_log_dir
 aidf_cleanup_old_logs
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
-    if [[ -n "$AIDF_HOOK_LOG_DIR" ]]; then
-        LOG_FILE="$AIDF_HOOK_LOG_DIR/$(LC_ALL=C date '+%Y-%m-%d')-error.log"
-        {
-            echo "========================================"
-            echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
-            echo "ERROR:  Configuration file not found"
-            echo "PATH:   $CONFIG_FILE"
-            echo "========================================"
-        } >> "$LOG_FILE"
-    fi
     echo "Error: Configuration file not found: $CONFIG_FILE" >&2
     exit 1
 fi
 
 INPUT=$(cat)
-PROJECT=$(aidf_extract_project_from_claude_input "$INPUT")
+PROJECT=$(aidf_extract_project_from_json_input "$INPUT")
 LOG_FILE="$(aidf_log_file_for_project "$PROJECT")"
 
 STDERR_FILE=$(mktemp)
 OUTPUT=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFIG_FILE" 2>"$STDERR_FILE") || {
-    COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command','<unknown>'))" 2>/dev/null || echo "<parse error>")
+    COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '<unknown>')" 2>/dev/null || echo "<parse error>")
     COMMAND=$(aidf_sanitize_for_log "$COMMAND")
     STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
     rm -f "$STDERR_FILE"
@@ -47,7 +37,6 @@ OUTPUT=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFIG_
             echo "TIME:   $(LC_ALL=C date '+%Y-%m-%d %H:%M:%S')"
             echo "ERROR:  Python script failed"
             echo "CMD:    $COMMAND"
-            echo "STDOUT: $OUTPUT"
             echo "STDERR: $STDERR_CONTENT"
             echo "========================================"
         } >> "$LOG_FILE"
@@ -57,9 +46,9 @@ OUTPUT=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/validate-bash.py" "$CONFIG_
 rm -f "$STDERR_FILE"
 
 if [[ -n "$LOG_FILE" ]]; then
-    if echo "$OUTPUT" | grep -q '"permissionDecision": *"deny"'; then
-        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
-        REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hookSpecificOutput',{}).get('permissionDecisionReason',''))" 2>/dev/null)
+    if echo "$OUTPUT" | grep -q '"decision": *"deny"'; then
+        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '')" 2>/dev/null)
+        REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason',''))" 2>/dev/null)
         COMMAND=$(aidf_sanitize_for_log "$COMMAND")
         REASON=$(aidf_sanitize_for_log "$REASON")
         {
@@ -70,9 +59,9 @@ if [[ -n "$LOG_FILE" ]]; then
             echo "CMD:    $COMMAND"
             echo "========================================"
         } >> "$LOG_FILE"
-    elif echo "$OUTPUT" | grep -q '"permissionDecision": *"ask"'; then
-        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
-        REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hookSpecificOutput',{}).get('permissionDecisionReason',''))" 2>/dev/null)
+    elif echo "$OUTPUT" | grep -q '"decision": *"ask"'; then
+        COMMAND=$(printf '%s' "$INPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); ti=data.get('tool_input') or data.get('toolInput') or {}; print(ti.get('command') or ti.get('commandLine') or '')" 2>/dev/null)
+        REASON=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason',''))" 2>/dev/null)
         COMMAND=$(aidf_sanitize_for_log "$COMMAND")
         REASON=$(aidf_sanitize_for_log "$REASON")
         {

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "aidf-bash-policy",
+            "type": "command",
+            "command": "$GEMINI_PROJECT_DIR/.gemini/hooks/validate-bash.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "aidf-bash-policy-post",
+            "type": "command",
+            "command": "$GEMINI_PROJECT_DIR/.gemini/hooks/post-bash.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Lint hook scripts
         run: |
           echo "Running shellcheck on hook scripts..."
-          find .claude/hooks -name "*.sh" -exec shellcheck {} \;
+          find .claude/hooks .gemini/hooks .codex/hooks .ai-dev-foundry/shared/hooks/bash-policy -name "*.sh" -exec shellcheck {} \;
 
       - name: Validate TOML config
         run: |
@@ -130,8 +130,8 @@ jobs:
               import tomli as tomllib
 
           errors = 0
-          toml_files = ['.claude/hooks/bash-patterns.toml'] + sorted(
-              glob.glob('.claude/hooks/bash-patterns.*.toml')
+          toml_files = ['.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml'] + sorted(
+              glob.glob('.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.*.toml')
           )
 
           for toml_path in toml_files:
@@ -208,7 +208,7 @@ jobs:
           errors=0
 
           echo "=== Checking shell scripts ==="
-          for script in .claude/hooks/*.sh scripts/*.sh scripts/git-subtree-mgr .github/workflows/scripts/*.sh; do
+          for script in .claude/hooks/*.sh .gemini/hooks/*.sh .codex/hooks/*.sh .ai-dev-foundry/shared/hooks/bash-policy/*.sh scripts/*.sh scripts/git-subtree-mgr .github/workflows/scripts/*.sh; do
             if [ -f "$script" ]; then
               echo -n "Checking $script... "
               if ! grep -q "Source:.*github.com/amulya-labs/ai-dev-foundry" "$script"; then
@@ -225,7 +225,7 @@ jobs:
 
           echo ""
           echo "=== Checking Python scripts ==="
-          for script in .claude/hooks/*.py .github/workflows/scripts/*.py; do
+          for script in .claude/hooks/*.py .gemini/hooks/*.py .codex/hooks/*.py .ai-dev-foundry/shared/hooks/bash-policy/*.py .github/workflows/scripts/*.py; do
             if [ -f "$script" ]; then
               echo -n "Checking $script... "
               if ! grep -q "Source:.*github.com/amulya-labs/ai-dev-foundry" "$script"; then
@@ -242,7 +242,7 @@ jobs:
 
           echo ""
           echo "=== Checking TOML configs ==="
-          for config in .claude/hooks/*.toml; do
+          for config in .ai-dev-foundry/shared/hooks/bash-policy/*.toml; do
             if [ -f "$config" ]; then
               echo -n "Checking $config... "
               if ! grep -q "Source:.*github.com/amulya-labs/ai-dev-foundry" "$config"; then

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,8 @@ concurrency:
       ||
     (github.event_name == 'issue_comment' &&
      github.event.issue.pull_request &&
-     startsWith(github.event.comment.body, '/claude-review') &&
+     (startsWith(github.event.comment.body, '/review') ||
+      startsWith(github.event.comment.body, '/claude-review')) &&
      github.actor != 'claude[bot]') &&
       format('{0}-issue_comment-pr-{1}', github.workflow, github.event.issue.number)
       ||
@@ -42,8 +43,8 @@ concurrency:
 jobs:
   claude-review:
     # Unified job: handles both public and non-public repos.
-    # For non-public repos: triggers on workflow_dispatch, same-repo pull_request, or authorized /claude-review comment.
-    # For public repos: triggers on authorized pull_request (MEMBER/OWNER/COLLABORATOR), workflow_dispatch with pr_number, or authorized /claude-review comment.
+    # For non-public repos: triggers on workflow_dispatch, same-repo pull_request, or authorized /review or /claude-review comment.
+    # For public repos: triggers on authorized pull_request (MEMBER/OWNER/COLLABORATOR), workflow_dispatch with pr_number, or authorized /review or /claude-review comment.
     if: |
       (
         github.event.repository.visibility != 'public' && (
@@ -52,7 +53,8 @@ jobs:
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            startsWith(github.event.comment.body, '/claude-review') &&
+            (startsWith(github.event.comment.body, '/review') ||
+             startsWith(github.event.comment.body, '/claude-review')) &&
             !contains(github.event.comment.body, '@claude') &&
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
           )
@@ -62,7 +64,8 @@ jobs:
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            startsWith(github.event.comment.body, '/claude-review') &&
+            (startsWith(github.event.comment.body, '/review') ||
+             startsWith(github.event.comment.body, '/claude-review')) &&
             !contains(github.event.comment.body, '@claude') &&
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
           ) ||
@@ -161,7 +164,7 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
         run: |
           case "$EVENT_NAME" in
-            issue_comment) TRIGGER="\`/claude-review\`" ;;
+            issue_comment) TRIGGER="\`/review\` or \`/claude-review\`" ;;
             pull_request)  TRIGGER="PR $EVENT_ACTION" ;;
             *)             TRIGGER="workflow dispatch" ;;
           esac
@@ -367,7 +370,7 @@ jobs:
           > 🤖 **Note:** The automated Claude code review did not complete — $REASON.
           >
           > Any inline comments posted above are valid findings, but the review may be incomplete.
-          > [View workflow run]($RUN_URL) for details. Re-trigger with \`/claude-review\`.
+          > [View workflow run]($RUN_URL) for details. Re-trigger with \`/review\` or \`/claude-review\`.
           EOF
 
           gh pr comment "$PR_NUM" \

--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -4,7 +4,6 @@
 name: Gemini Code Review
 
 env:
-  WORKFLOW_VERSION: ${{ github.sha }}
   INLINE_ATTRIBUTION: "\n\n---\n_\U0001f48e [Gemini](https://gemini.google.com/) via [ai-dev-foundry](https://github.com/amulya-labs/ai-dev-foundry)_"
 
 on:

--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -14,7 +14,8 @@ on:
 concurrency:
   group: ${{
     (github.event.issue.pull_request &&
-     (startsWith(github.event.comment.body, '/gemini-light-review') ||
+     (startsWith(github.event.comment.body, '/review') ||
+      startsWith(github.event.comment.body, '/gemini-light-review') ||
       startsWith(github.event.comment.body, '/gemini-deep-review') ||
       startsWith(github.event.comment.body, '/gemini-pro-review') ||
       startsWith(github.event.comment.body, '/gemini-review'))) &&
@@ -32,6 +33,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       (
+        startsWith(github.event.comment.body, '/review') ||
         startsWith(github.event.comment.body, '/gemini-light-review') ||
         startsWith(github.event.comment.body, '/gemini-deep-review') ||
         startsWith(github.event.comment.body, '/gemini-pro-review') ||
@@ -208,6 +210,7 @@ jobs:
           if [[ "$COMMENT_BODY" == /gemini-pro-review* ]]; then RETRIGGER="/gemini-pro-review"
           elif [[ "$COMMENT_BODY" == /gemini-deep-review* ]]; then RETRIGGER="/gemini-deep-review"
           elif [[ "$COMMENT_BODY" == /gemini-light-review* ]]; then RETRIGGER="/gemini-light-review"
+          elif [[ "$COMMENT_BODY" == /review* ]]; then RETRIGGER="/review"
           else RETRIGGER="/gemini-review"; fi
 
           cat > /tmp/failure-notice.md <<EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ shellcheck .claude/hooks/*.sh .gemini/hooks/*.sh .codex/hooks/*.sh .ai-dev-found
   validate-bash.sh       -- Shell entry point: reads Claude JSON, calls validate-bash.py, logs
   validate-bash.py       -- Claude adapter: normalizes hook input/output for the shared engine
   post-bash.sh           -- Claude PostToolUse adapter: logs ASK->APPROVED outcomes
+  validate-bash.sh       -- Gemini shell entry point: reads Gemini JSON, calls validate-bash.py, logs
+  validate-bash.py       -- Gemini adapter: normalizes hook input/output for the shared engine
+  post-bash.sh           -- Gemini AfterTool adapter: logs ASK->APPROVED outcomes
+  validate-bash.sh       -- Codex shell entry point: reads Codex JSON, calls validate-bash.py, logs
+  validate-bash.py       -- Codex adapter: normalizes hook input/output for the shared engine
+  post-bash.sh           -- Codex PostToolUse adapter: logs ASK->APPROVED outcomes
 .ai-dev-foundry/shared/hooks/bash-policy/ -- Provider-neutral Bash policy engine
   validate-command.py    -- Shared validator with normalized JSON contract
   hook-lib.sh            -- Shared shell logging/path helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ tests/test-validate-bash.sh allow    # or: ask, deny
 tests/test-manage-agents.sh
 
 # Lint hook scripts
-shellcheck .claude/hooks/*.sh
+shellcheck .claude/hooks/*.sh .gemini/hooks/*.sh .codex/hooks/*.sh .ai-dev-foundry/shared/hooks/bash-policy/*.sh
 
 # Validate TOML config syntax
-python3 -c "import tomllib; tomllib.load(open('.claude/hooks/bash-patterns.toml','rb')); print('TOML ok')"
+python3 -c "import tomllib; tomllib.load(open('.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml','rb')); print('TOML ok')"
 
 # Validate agent frontmatter
 python3 -c "
@@ -47,8 +47,8 @@ for f in Path('.claude/agents').glob('*.md'):
 "
 
 # Full CI-equivalent local check (run before pushing)
-shellcheck .claude/hooks/*.sh && \
-  python3 -c "import tomllib; tomllib.load(open('.claude/hooks/bash-patterns.toml','rb'))" && \
+shellcheck .claude/hooks/*.sh .gemini/hooks/*.sh .codex/hooks/*.sh .ai-dev-foundry/shared/hooks/bash-policy/*.sh && \
+  python3 -c "import tomllib; tomllib.load(open('.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml','rb'))" && \
   pytest tests/test_validate_bash.py -v && \
   tests/test-validate-bash.sh && \
   tests/test-manage-agents.sh
@@ -58,15 +58,22 @@ shellcheck .claude/hooks/*.sh && \
 
 ```
 .claude/agents/          -- agent markdown files with YAML frontmatter; add/edit agents here
-.claude/hooks/           -- PreToolUse/PostToolUse bash command validation hooks
-  validate-bash.sh       -- Shell entry point: reads stdin JSON, calls validate-bash.py, logs
-  validate-bash.py       -- Python validator: splits chains, cleans segments, matches patterns
+.claude/hooks/           -- Claude-specific PreToolUse/PostToolUse adapters
+.gemini/hooks/           -- Gemini CLI BeforeTool/AfterTool adapters
+.codex/hooks/            -- Codex PreToolUse/PostToolUse adapters
+  validate-bash.sh       -- Shell entry point: reads Claude JSON, calls validate-bash.py, logs
+  validate-bash.py       -- Claude adapter: normalizes hook input/output for the shared engine
+  post-bash.sh           -- Claude PostToolUse adapter: logs ASK->APPROVED outcomes
+.ai-dev-foundry/shared/hooks/bash-policy/ -- Provider-neutral Bash policy engine
+  validate-command.py    -- Shared validator with normalized JSON contract
+  hook-lib.sh            -- Shared shell logging/path helpers
   bash-patterns.toml     -- Universal regex patterns: [deny.*], [ask.*], [allow.*]
   bash-patterns.linux.toml  -- Linux-specific pattern overlay (merged at runtime)
   bash-patterns.darwin.toml -- macOS-specific pattern overlay (merged at runtime)
   bash-patterns.windows.toml -- Windows/Git Bash pattern overlay (merged at runtime)
-  post-bash.sh           -- PostToolUse hook: logs ASK->APPROVED outcomes
-.claude/settings.json    -- Hook wiring + permission allow/deny lists (shared/committed)
+.claude/settings.json    -- Claude hook wiring + permission allow/deny lists (shared/committed)
+.gemini/settings.json    -- Gemini CLI hook wiring (shared/committed)
+.codex/hooks.json        -- Codex hook wiring (shared/committed)
 .claude/settings.local.json -- Local-only permission overrides (committed but for local use)
 scripts/manage-ai-configs.sh -- Install/update AI agent configs and GHA workflows via curl from GitHub
 scripts/git-subtree-mgr  -- Git subtree manager for tracking upstream changes
@@ -88,8 +95,8 @@ tests/                   -- All tests: bash-test-cases.toml, test_validate_bash.
 - Must be generalized (no project-specific references), focused (one domain per agent)
 
 ### Hook Patterns
-- Edit `.claude/hooks/bash-patterns.toml` for universal (cross-platform) patterns
-- Edit `.claude/hooks/bash-patterns.{linux,darwin,windows}.toml` for OS-specific patterns
+- Edit `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml` for universal (cross-platform) patterns
+- Edit `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.{linux,darwin,windows}.toml` for OS-specific patterns
 - **OS-aware layering**: the validator auto-detects the OS via `sys.platform` and merges the matching OS file on top of the base file. OS patterns are **appended** to matching base sections (never replace). New sections from OS files are added as-is.
 - Categories: `[deny.*]` (always block), `[ask.*]` (prompt user), `[allow.*]` (auto-approve)
 - Evaluation order: deny -> ask -> allow -> ask (default if no match)
@@ -100,8 +107,9 @@ tests/                   -- All tests: bash-test-cases.toml, test_validate_bash.
 - **Where to add patterns**: cross-platform commands go in `bash-patterns.toml`; OS-specific commands (e.g. `systemd-analyze` for Linux, `defaults write` for macOS) go in the matching OS file
 
 ### Hook Logic
-- Edit `.claude/hooks/validate-bash.py` for validator behavior
-- The shell wrapper (`validate-bash.sh`) handles logging only; do not add validation logic there
+- Edit `.ai-dev-foundry/shared/hooks/bash-policy/validate-command.py` for shared validator behavior
+- Edit `.claude/hooks/validate-bash.py`, `.gemini/hooks/validate-bash.py`, or `.codex/hooks/validate-bash.py` only for provider-specific translation
+- The shell wrapper (`validate-bash.sh`) handles logging and adapter invocation only; do not add validation logic there
 - The validator splits chains (`&&`, `||`, `;`), cleans segments (strips env vars, subshell chars, control flow keywords), then matches each segment against patterns independently
 - A chain is allowed only if ALL segments are allowed; any ask/deny segment escalates the whole chain
 
@@ -112,7 +120,7 @@ tests/                   -- All tests: bash-test-cases.toml, test_validate_bash.
 - Tests are data-driven: both `test_validate_bash.py` and `test-validate-bash.sh` read from this file
 
 ### Attribution
-- All `.sh`, `.py`, and `.toml` files under `.claude/hooks/` and `scripts/`, and all owned workflow files under `.github/workflows/` (`ci.yml`, `claude.yml`, `claude-code-review.yml`), must contain:
+- All `.sh`, `.py`, and `.toml` files under `.claude/hooks/`, `.gemini/hooks/`, `.codex/hooks/`, `.ai-dev-foundry/shared/hooks/bash-policy/`, and `scripts/`, and all owned workflow files under `.github/workflows/` (`ci.yml`, `claude.yml`, `claude-code-review.yml`), must contain:
   ```
   # Source: https://github.com/amulya-labs/ai-dev-foundry
   # License: MIT (https://opensource.org/licenses/MIT)
@@ -137,13 +145,13 @@ tests/                   -- All tests: bash-test-cases.toml, test_validate_bash.
 |---------|-------------|-----|
 | `Error: Python 3.11+ required` | Python < 3.11 without `tomli` | `pip install tomli` or upgrade Python |
 | Hook returns empty output | Empty or malformed JSON input | Check structure: `{"tool_input":{"command":"..."}}` |
-| Safe command triggers ASK | Command not in allow patterns, or ask pattern matches first | Check pattern order in `bash-patterns.toml` or OS-specific file; add allow pattern; add test case |
-| OS-specific command triggers ASK | Pattern missing from OS overlay file | Add pattern to `bash-patterns.{linux,darwin,windows}.toml`; add test case with `os` field |
+| Safe command triggers ASK | Command not in allow patterns, or ask pattern matches first | Check pattern order in `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml` or OS-specific file; add allow pattern; add test case |
+| OS-specific command triggers ASK | Pattern missing from OS overlay file | Add pattern to `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.{linux,darwin,windows}.toml`; add test case with `os` field |
 | Safe chain triggers ASK | One segment in the chain is unrecognized | The validator checks each segment independently; add an allow pattern for the unrecognized segment |
 | CI fails: "missing attribution" | New/edited script missing header comments | Add `Source:` and `License:` comments (see Attribution above) |
 | CI fails: agent frontmatter | Missing `name`/`description`/`source`/`license` or invalid YAML | Check frontmatter between `---` delimiters |
 | Pattern regex error in stderr | Invalid regex in `bash-patterns.toml` | Python `re` module syntax applies; check the reported pattern |
-| Hook logs filling disk | Logs at `/tmp/claude-hook-logs/` with 15-day retention | Auto-cleanup runs daily; manual: `rm /tmp/claude-hook-logs/*.log` |
+| Hook logs filling disk | Logs at `/tmp/ai-dev-foundry-hook-logs/` with 15-day retention | Auto-cleanup runs daily; manual: `rm /tmp/ai-dev-foundry-hook-logs/*.log` |
 
 ## CI/CD Notes
 
@@ -155,8 +163,8 @@ tests/                   -- All tests: bash-test-cases.toml, test_validate_bash.
 
 - **No secrets in this repo** -- it is a public config/agent collection
 - **settings.local.json** is committed but intended for local-only permission overrides
-- **Hook logs** go to `/tmp/claude-hook-logs/` (not in repo); only ASK/DENY are logged; ALLOW is silent
-- **Deny patterns** in `bash-patterns.toml` cannot be overridden -- this is by design for safety
+- **Hook logs** go to `/tmp/ai-dev-foundry-hook-logs/` (not in repo); only ASK/DENY are logged; ALLOW is silent
+- **Deny patterns** in `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml` cannot be overridden -- this is by design for safety
 - **Never push directly to main** -- always branch and PR
 - **Do not add transient/status documentation to the repo** -- use GitHub issues for plans and tracking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Agent instructions in markdown...
 
 ## Hooks
 
-The `.claude/hooks/` directory contains hooks that validate and log Bash commands.
+Provider-specific hook adapters live in `.claude/hooks/`, `.gemini/hooks/`, and `.codex/hooks/`. The provider-neutral Bash policy core lives in `.ai-dev-foundry/shared/hooks/bash-policy/`.
 
 | Hook | File | Purpose |
 |------|------|---------|
@@ -40,7 +40,7 @@ The `.claude/hooks/` directory contains hooks that validate and log Bash command
 
 ### Bash Command Validation
 
-The `validate-bash.sh` hook validates Bash commands against pattern lists in `bash-patterns.toml` and OS-specific overlay files.
+The provider adapters (`.claude/hooks/validate-bash.sh`, `.gemini/hooks/validate-bash.sh`, and `.codex/hooks/validate-bash.sh`) validate Bash commands through the shared policy engine in `.ai-dev-foundry/shared/hooks/bash-policy/`, which loads `bash-patterns.toml` and the OS-specific overlay files.
 
 **How it works:**
 
@@ -59,7 +59,7 @@ The `validate-bash.sh` hook validates Bash commands against pattern lists in `ba
 
 ### Customizing Patterns
 
-Edit `.claude/hooks/bash-patterns.toml` for cross-platform patterns, or the OS-specific overlay files for platform-specific commands:
+Edit `.ai-dev-foundry/shared/hooks/bash-policy/bash-patterns.toml` for cross-platform patterns, or the OS-specific overlay files for platform-specific commands:
 
 | File | Platform | When loaded |
 |------|----------|-------------|
@@ -93,7 +93,7 @@ Patterns are regular expressions. Use `^` to anchor to the start of the command.
 
 Hooks log `ASK` and `DENY` decisions (not `ALLOW`) to reduce disk I/O:
 
-- **Location:** `/tmp/claude-hook-logs/`
+- **Location:** `/tmp/ai-dev-foundry-hook-logs/`
 - **Format:** `YYYY-MM-DD-Day-<project>.log`
 - **Retention:** 15 days (auto-cleanup)
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cp -r ai-dev-foundry/.claude/ /path/to/your/project/.claude/
 
 ## Hooks
 
-The `.claude/hooks/` directory includes Bash command validation hooks that auto-approve safe commands and block dangerous ones. Patterns are defined in `bash-patterns.toml`.
+The shared Bash command validation engine lives in `.ai-dev-foundry/shared/hooks/bash-policy/`. Thin adapters now live in `.claude/hooks/`, `.gemini/hooks/`, and `.codex/hooks/`, so the same allow/ask/deny policy can be reused across Claude Code, Gemini CLI, and Codex without duplicating rules. OpenCode is still pending because its current CLI docs do not expose a comparable project hook surface.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for hook configuration details.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Trigger manually by commenting `/review` or `/gemini-review` on any PR (members/
 
 All `*-code-review.yml` workflows should opt in to the shared `/review` PR comment trigger alongside any agent-specific commands such as `/claude-review` or `/gemini-review`. This keeps the default review fan-out convention-based and avoids a separate dispatcher workflow.
 
+If both Claude and Gemini review workflows are installed, `/review` triggers both of them. Teams that want a single reviewer should disable the other workflow or use the provider-specific trigger instead.
+
 ### NotebookLM Sync
 
 Flattens your codebase into word-limited text sources using [repomix](https://github.com/yamadashy/repomix) and uploads them to a NotebookLM notebook on every push to main. Useful for keeping a "project brain" notebook up to date without manual effort.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Run `./scripts/manage-ai-configs.sh` or `git-subtree-mgr --help` for usage.
 
 | Workflow | Purpose | Trigger |
 |----------|---------|---------|
-| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/claude-review` comment |
-| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | PR opened/updated; `/gemini-review` comment |
+| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/review` or `/claude-review` comment |
+| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | `/review` or `/gemini-review` comment |
 | `sync-notebooklm.yml` | Flatten repo into text sources and sync to NotebookLM | Push to main; manual dispatch |
 
 ### Gemini Code Review Setup
@@ -174,7 +174,11 @@ Add your Gemini API key as a repository secret named `GEMINI_API_KEY`. The workf
 - **Gemini Flash** for the narrative PR summary (fast, quota-efficient)
 - **Gemini Pro** for line-level inline comments (deep reasoning)
 
-Trigger manually by commenting `/gemini-review` on any PR (members/owners/collaborators only).
+Trigger manually by commenting `/review` or `/gemini-review` on any PR (members/owners/collaborators only).
+
+### Shared Review Command Convention
+
+All `*-code-review.yml` workflows should opt in to the shared `/review` PR comment trigger alongside any agent-specific commands such as `/claude-review` or `/gemini-review`. This keeps the default review fan-out convention-based and avoids a separate dispatcher workflow.
 
 ### NotebookLM Sync
 

--- a/scripts/manage-ai-configs.sh
+++ b/scripts/manage-ai-configs.sh
@@ -28,6 +28,10 @@ WITH_GHA_WORKFLOWS=false
 
 # Provider registry — to add a new provider, add entries here only
 # (Variables are referenced via indirect expansion; SC2034 is suppressed per-variable)
+# Shared provider-neutral assets are installed once under this directory and can
+# be reused by multiple CLI adapters (Claude, Codex, Gemini CLI, OpenCode, etc.).
+SHARED_CONFIG_DIR=".ai-dev-foundry"
+
 # shellcheck disable=SC2034
 PROVIDER_CLAUDE_WORKFLOWS="claude.yml claude-code-review.yml"
 # shellcheck disable=SC2034
@@ -41,6 +45,9 @@ PROVIDER_CLAUDE_CONFIG_DIR=".claude"
 # Supported item types: "agents" (dir), "hooks" (dir), "settings.json" (file)
 # shellcheck disable=SC2034
 PROVIDER_CLAUDE_CONFIG_ITEMS="agents hooks settings.json"
+# Optional shared items installed under $SHARED_CONFIG_DIR
+# shellcheck disable=SC2034
+PROVIDER_CLAUDE_SHARED_ITEMS="shared/hooks/bash-policy"
 
 # shellcheck disable=SC2034
 PROVIDER_GEMINI_WORKFLOWS="gemini-code-review.yml"
@@ -54,7 +61,25 @@ PROVIDER_GEMINI_WORKFLOW_SCRIPTS="gemini_review.py gemini_review_workflow.sh"
 # Extra files to install alongside workflows (relative to repo root)
 # shellcheck disable=SC2034
 PROVIDER_GEMINI_EXTRA_FILES=".github/gemini-cache-manifest.yml"
-# Gemini has no local config dir yet — leave unset
+# shellcheck disable=SC2034
+PROVIDER_GEMINI_CONFIG_DIR=".gemini"
+# shellcheck disable=SC2034
+PROVIDER_GEMINI_CONFIG_ITEMS="hooks settings.json"
+# shellcheck disable=SC2034
+PROVIDER_GEMINI_SHARED_ITEMS="shared/hooks/bash-policy"
+
+# shellcheck disable=SC2034
+PROVIDER_CODEX_WORKFLOWS=""
+# shellcheck disable=SC2034
+PROVIDER_CODEX_SECRETS=""
+# shellcheck disable=SC2034
+PROVIDER_CODEX_LABEL="Codex"
+# shellcheck disable=SC2034
+PROVIDER_CODEX_CONFIG_DIR=".codex"
+# shellcheck disable=SC2034
+PROVIDER_CODEX_CONFIG_ITEMS="hooks hooks.json"
+# shellcheck disable=SC2034
+PROVIDER_CODEX_SHARED_ITEMS="shared/hooks/bash-policy"
 
 # shellcheck disable=SC2034
 PROVIDER_NOTEBOOKLM_WORKFLOWS="sync-notebooklm.yml"
@@ -173,8 +198,14 @@ download_provider_workflows() {
     local label="${!label_var}"
     local secrets="${!secrets_var}"
     local workflows="${!workflows_var}"
+    local scripts_var="PROVIDER_${upper}_WORKFLOW_SCRIPTS"
+    local extra_var="PROVIDER_${upper}_EXTRA_FILES"
     local -a wf_list
     read -ra wf_list <<< "$workflows"
+
+    if [[ ${#wf_list[@]} -eq 0 ]] && [[ ! -v "$scripts_var" || -z "${!scripts_var}" ]] && [[ ! -v "$extra_var" || -z "${!extra_var}" ]]; then
+        return 0
+    fi
 
     info "Fetching ${label} GitHub Actions workflows..."
     local workflow_dir=".github/workflows"
@@ -189,7 +220,6 @@ download_provider_workflows() {
     done
 
     # Also download workflow helper scripts if defined for this provider
-    local scripts_var="PROVIDER_${upper}_WORKFLOW_SCRIPTS"
     if [[ -v "$scripts_var" ]] && [[ -n "${!scripts_var}" ]]; then
         local -a script_list
         read -ra script_list <<< "${!scripts_var}"
@@ -207,7 +237,6 @@ download_provider_workflows() {
     fi
 
     # Download extra files if defined for this provider
-    local extra_var="PROVIDER_${upper}_EXTRA_FILES"
     if [[ -v "$extra_var" ]] && [[ -n "${!extra_var}" ]]; then
         local -a extra_list
         read -ra extra_list <<< "${!extra_var}"
@@ -239,6 +268,18 @@ post_download_claude() {
         chmod +x "${config_dir}/hooks/"*.sh 2>/dev/null || true
         chmod +x "${config_dir}/hooks/"*.py 2>/dev/null || true
     fi
+    if [ -d "${SHARED_CONFIG_DIR}/shared/hooks/bash-policy" ]; then
+        chmod +x "${SHARED_CONFIG_DIR}/shared/hooks/bash-policy/"*.sh 2>/dev/null || true
+        chmod +x "${SHARED_CONFIG_DIR}/shared/hooks/bash-policy/"*.py 2>/dev/null || true
+    fi
+}
+
+post_download_gemini() {
+    post_download_claude "$1"
+}
+
+post_download_codex() {
+    post_download_claude "$1"
 }
 
 # Merge upstream settings.json into an existing local settings.json.
@@ -324,54 +365,70 @@ download_provider_config() {
     upper=$(printf '%s' "$provider" | tr '[:lower:]' '[:upper:]')
     local config_dir_var="PROVIDER_${upper}_CONFIG_DIR"
     local config_items_var="PROVIDER_${upper}_CONFIG_ITEMS"
-
-    # Provider has no local config dir — nothing to download
-    [[ ! -v "$config_dir_var" ]] && return 0
-
-    local config_dir="${!config_dir_var}"
-    local config_items="${!config_items_var:-}"
+    local shared_items_var="PROVIDER_${upper}_SHARED_ITEMS"
+    local shared_items="${!shared_items_var:-}"
     local label_var="PROVIDER_${upper}_LABEL"
     local label="${!label_var}"
 
-    info "Syncing ${label} local config in ${config_dir}..."
-    mkdir -p "$config_dir"
+    if [[ ! -v "$config_dir_var" ]] && [[ -z "$shared_items" ]]; then
+        return 0
+    fi
 
-    local item
-    local -a _items
-    read -ra _items <<< "$config_items"
-    for item in "${_items[@]}"; do
-        if [[ "$item" == *.* ]]; then
-            # Single file (e.g. settings.json)
-            info "Fetching ${item}..."
-            local tmp_file
-            tmp_file=$(mktemp)
-            if curl -fsSL "$RAW_BASE/.${provider}/${item}" -o "$tmp_file" 2>/dev/null; then
-                if [[ "$item" == "settings.json" ]] && [[ -f "${config_dir}/${item}" ]] && [[ -s "${config_dir}/${item}" ]]; then
-                    # Merge upstream settings into existing local settings
-                    local merged_file
-                    merged_file=$(mktemp)
-                    if merge_settings_json "$tmp_file" "${config_dir}/${item}" "$merged_file"; then
-                        mv "$merged_file" "${config_dir}/${item}"
-                        info "  Merged ${item} (preserved local customizations)"
+    if [[ -v "$config_dir_var" ]]; then
+        local config_dir="${!config_dir_var}"
+        local config_items="${!config_items_var:-}"
+
+        info "Syncing ${label} local config in ${config_dir}..."
+        mkdir -p "$config_dir"
+
+        local item
+        local -a _items
+        read -ra _items <<< "$config_items"
+        for item in "${_items[@]}"; do
+            if [[ "$item" == *.* ]]; then
+                # Single file (e.g. settings.json)
+                info "Fetching ${item}..."
+                local tmp_file
+                tmp_file=$(mktemp)
+                if curl -fsSL "$RAW_BASE/.${provider}/${item}" -o "$tmp_file" 2>/dev/null; then
+                    if [[ "$item" == "settings.json" ]] && [[ -f "${config_dir}/${item}" ]] && [[ -s "${config_dir}/${item}" ]]; then
+                        # Merge upstream settings into existing local settings
+                        local merged_file
+                        merged_file=$(mktemp)
+                        if merge_settings_json "$tmp_file" "${config_dir}/${item}" "$merged_file"; then
+                            mv "$merged_file" "${config_dir}/${item}"
+                            info "  Merged ${item} (preserved local customizations)"
+                        else
+                            warn "  Merge failed for ${item} — overwriting with upstream"
+                            cp "$tmp_file" "${config_dir}/${item}"
+                            rm -f "$merged_file"
+                        fi
                     else
-                        warn "  Merge failed for ${item} — overwriting with upstream"
                         cp "$tmp_file" "${config_dir}/${item}"
-                        rm -f "$merged_file"
+                        info "  Downloaded ${item}"
                     fi
+                    rm -f "$tmp_file"
                 else
-                    cp "$tmp_file" "${config_dir}/${item}"
-                    info "  Downloaded ${item}"
+                    rm -f "$tmp_file"
+                    warn "  ${item} not found (optional)"
                 fi
-                rm -f "$tmp_file"
             else
-                rm -f "$tmp_file"
-                warn "  ${item} not found (optional)"
+                # Directory
+                download_dir ".${provider}/${item}" "${config_dir}/${item}"
             fi
-        else
-            # Directory
-            download_dir ".${provider}/${item}" "${config_dir}/${item}"
-        fi
-    done
+        done
+    fi
+
+    if [[ -n "$shared_items" ]]; then
+        info "Syncing shared hook core in ${SHARED_CONFIG_DIR}..."
+        mkdir -p "$SHARED_CONFIG_DIR"
+        local shared_item
+        local -a _shared_items
+        read -ra _shared_items <<< "$shared_items"
+        for shared_item in "${_shared_items[@]}"; do
+            download_dir "${SHARED_CONFIG_DIR}/${shared_item}" "${SHARED_CONFIG_DIR}/${shared_item}"
+        done
+    fi
 
     # Provider-specific post-download steps
     local post_fn="post_download_${provider}"
@@ -406,6 +463,10 @@ stage_downloaded_files() {
         if [[ -v "$_cdir_var" ]]; then
             git add "${!_cdir_var}" 2>/dev/null || true
         fi
+        local _shared_var="PROVIDER_${_up}_SHARED_ITEMS"
+        if [[ -v "$_shared_var" ]] && [[ -n "${!_shared_var}" ]]; then
+            git add "$SHARED_CONFIG_DIR" 2>/dev/null || true
+        fi
         local _extra_var="PROVIDER_${_up}_EXTRA_FILES"
         if [[ -v "$_extra_var" ]] && [[ -n "${!_extra_var}" ]]; then
             local -a _extra_list
@@ -425,7 +486,20 @@ print_provider_summary() {
         _up=$(printf '%s' "$_p" | tr '[:lower:]' '[:upper:]')
         local label_var="PROVIDER_${_up}_LABEL"
         local secrets_var="PROVIDER_${_up}_SECRETS"
-        info "${!label_var} workflows ${verb} in .github/workflows/"
+        local config_dir_var="PROVIDER_${_up}_CONFIG_DIR"
+        local shared_var="PROVIDER_${_up}_SHARED_ITEMS"
+        local workflows_var="PROVIDER_${_up}_WORKFLOWS"
+        local scripts_var="PROVIDER_${_up}_WORKFLOW_SCRIPTS"
+        local extra_var="PROVIDER_${_up}_EXTRA_FILES"
+        if [[ -v "$config_dir_var" ]]; then
+            info "${!label_var} local config ${verb} in ${!config_dir_var}/"
+        fi
+        if [[ -v "$shared_var" ]] && [[ -n "${!shared_var}" ]]; then
+            info "${!label_var} shared hook core ${verb} in ${SHARED_CONFIG_DIR}/"
+        fi
+        if [[ -v "$workflows_var" && -n "${!workflows_var}" ]] || [[ -v "$scripts_var" && -n "${!scripts_var}" ]] || [[ -v "$extra_var" && -n "${!extra_var}" ]]; then
+            info "${!label_var} workflows ${verb} in .github/workflows/"
+        fi
         local -a _secrets_list
         read -ra _secrets_list <<< "${!secrets_var}"
         for _s in "${_secrets_list[@]}"; do
@@ -506,22 +580,29 @@ usage_claude() {
     echo ""
     echo "Options:"
     echo "  --gemini               Also install Gemini PR review workflow"
-    echo "  --ai <providers>       Comma-separated provider list (e.g. claude,gemini,notebooklm)"
+    echo "  --ai <providers>       Comma-separated provider list (e.g. claude,gemini,codex,notebooklm)"
     echo "  --with-gha-workflows   Also install extra workflow templates from"
     echo "                         github-workflow-templates/ in the source repo"
     echo ""
     echo "This downloads:"
     echo "  .claude/agents/   - Reusable Claude Code agents"
-    echo "  .claude/hooks/    - PreToolUse hooks (e.g., bash validation)"
+    echo "  .claude/hooks/    - Claude hook adapters"
+    echo "  .ai-dev-foundry/shared/hooks/bash-policy/ - Shared Bash policy engine"
     echo "  .claude/settings.json - Hook configuration"
     echo "  .github/workflows/claude.yml             - @claude mention handler"
     echo "  .github/workflows/claude-code-review.yml - Auto PR review"
     echo "  (requires CLAUDE_CODE_OAUTH_TOKEN secret in repo)"
     echo ""
     echo "With --gemini or --ai claude,gemini, also downloads:"
+    echo "  .gemini/hooks/                             - Gemini CLI hook adapters"
+    echo "  .gemini/settings.json                      - Gemini CLI hook configuration"
     echo "  .github/workflows/gemini-code-review.yml          - Gemini PR review (Flash + Pro)"
     echo "  .github/workflows/scripts/gemini_review.py        - Inline review Python helper"
     echo "  (requires GEMINI_API_KEY secret in repo)"
+    echo ""
+    echo "With --ai claude,codex, also downloads:"
+    echo "  .codex/hooks/      - Codex hook adapters"
+    echo "  .codex/hooks.json  - Codex hook configuration"
     echo ""
     echo "With --with-gha-workflows, also downloads:"
     echo "  Extra workflow templates from github-workflow-templates/"
@@ -531,10 +612,13 @@ usage_gemini() {
     echo "Usage: $0 gemini <command> [options]"
     echo ""
     echo "Commands:"
-    echo "  install   Add Gemini workflow to your project (first-time setup)"
-    echo "  update    Pull the latest Gemini workflow"
+    echo "  install   Add Gemini CLI hooks and workflow to your project (first-time setup)"
+    echo "  update    Pull the latest Gemini CLI hooks and workflow"
     echo ""
     echo "This downloads:"
+    echo "  .gemini/hooks/                             - Gemini CLI hook adapters"
+    echo "  .gemini/settings.json                      - Gemini CLI hook configuration"
+    echo "  .ai-dev-foundry/shared/hooks/bash-policy/  - Shared Bash policy engine"
     echo "  .github/workflows/gemini-code-review.yml          - Gemini PR review (Flash + Pro)"
     echo "  .github/workflows/scripts/gemini_review.py        - Inline review Python helper"
     echo "  (requires GEMINI_API_KEY secret in your repo settings)"
@@ -543,6 +627,24 @@ usage_gemini() {
     echo "  --with-gha-workflows   Also install extra workflow templates"
     echo "  --ai <providers>       Comma-separated provider list (accepted; use 'gemini' or 'all' instead)"
     echo "  --gemini               Equivalent to using the 'gemini' subcommand (accepted)"
+}
+
+usage_codex() {
+    echo "Usage: $0 codex <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  install   Add Codex hooks to your project (first-time setup)"
+    echo "  update    Pull the latest Codex hooks"
+    echo ""
+    echo "This downloads:"
+    echo "  .codex/hooks/                             - Codex hook adapters"
+    echo "  .codex/hooks.json                         - Codex hook configuration"
+    echo "  .ai-dev-foundry/shared/hooks/bash-policy/ - Shared Bash policy engine"
+    echo ""
+    echo "Options:"
+    echo "  --with-gha-workflows   Also install extra workflow templates"
+    echo "  --ai <providers>       Comma-separated provider list"
+    echo "  --gemini               Also install Gemini workflows/hooks"
 }
 
 usage_notebooklm() {
@@ -599,8 +701,13 @@ usage_main() {
         _pname="${_pname%_LABEL}"
         _plower=$(printf '%s' "$_pname" | tr '[:upper:]' '[:lower:]')
         _cfg_var="PROVIDER_${_pname}_CONFIG_DIR"
+        local _shared_var="PROVIDER_${_pname}_SHARED_ITEMS"
         if [[ -v "$_cfg_var" ]]; then
-            _descr="config, hooks, and GitHub Actions workflows"
+            if [[ -v "$_shared_var" ]]; then
+                _descr="provider adapters + shared hook core + GitHub Actions workflows"
+            else
+                _descr="config, hooks, and GitHub Actions workflows"
+            fi
         else
             _descr="GitHub Actions workflows only"
         fi
@@ -614,14 +721,15 @@ usage_main() {
     echo ""
     echo "Global options:"
     echo "  --gemini               Also install Gemini workflows (with claude)"
-    echo "  --ai <providers>       Comma-separated provider list (e.g. claude,gemini)"
+    echo "  --ai <providers>       Comma-separated provider list (e.g. claude,gemini,codex)"
     echo "  --with-gha-workflows   Also install extra workflow templates"
     echo ""
     echo "Quick start:"
     echo "  $0 claude install            # Claude agents, hooks, settings + workflows"
-    echo "  $0 gemini install            # Gemini PR review workflow"
+    echo "  $0 gemini install            # Gemini CLI hooks + PR review workflow"
+    echo "  $0 codex install             # Codex hooks"
     echo "  $0 all install               # All providers"
-    echo "  $0 claude install --gemini   # Claude + Gemini"
+    echo "  $0 claude install --ai gemini,codex   # Claude + Gemini + Codex"
     echo ""
     echo "Run '$0 <provider>' for provider-specific usage."
 }
@@ -713,7 +821,7 @@ handle_provider_command() {
 }
 
 case "$AGENT" in
-    claude|gemini|notebooklm)
+    claude|gemini|codex|notebooklm)
         handle_provider_command "$AGENT" "${1:-}"
         ;;
     all)

--- a/tests/test-manage-agents.sh
+++ b/tests/test-manage-agents.sh
@@ -73,6 +73,25 @@ else
     assert ".github/gemini-cache-manifest.yml exists" "fail" "File not found"
 fi
 
+EXPECTED_PROVIDER_FILES=(
+    .codex/hooks.json
+    .codex/hooks/validate-bash.sh
+    .codex/hooks/validate-bash.py
+    .codex/hooks/post-bash.sh
+    .gemini/settings.json
+    .gemini/hooks/validate-bash.sh
+    .gemini/hooks/validate-bash.py
+    .gemini/hooks/post-bash.sh
+)
+
+for f in "${EXPECTED_PROVIDER_FILES[@]}"; do
+    if [[ -f "$REPO_ROOT/$f" ]]; then
+        assert "$f exists" "pass"
+    else
+        assert "$f exists" "fail" "File not found"
+    fi
+done
+
 # gha-workflow-templates/ should no longer exist
 if [[ ! -d "$REPO_ROOT/gha-workflow-templates" ]]; then
     assert "gha-workflow-templates/ directory removed" "pass"
@@ -167,6 +186,13 @@ if grep -q 'PROVIDER_GEMINI_LABEL=' "$MANAGE_SCRIPT"; then
 else
     assert "PROVIDER_GEMINI_LABEL is defined" "fail" \
         "Expected PROVIDER_GEMINI_LABEL= in script"
+fi
+
+if grep -q 'PROVIDER_CODEX_LABEL=' "$MANAGE_SCRIPT"; then
+    assert "PROVIDER_CODEX_LABEL is defined" "pass"
+else
+    assert "PROVIDER_CODEX_LABEL is defined" "fail" \
+        "Expected PROVIDER_CODEX_LABEL= in script"
 fi
 
 echo
@@ -305,6 +331,46 @@ if grep -q 'gemini-cache-manifest.yml' "$MANAGE_SCRIPT"; then
 else
     assert "Script references gemini-cache-manifest.yml" "fail" \
         "Expected gemini-cache-manifest.yml in PROVIDER_GEMINI_EXTRA_FILES"
+fi
+
+echo
+
+# ── Codex provider checks ───────────────────────────────────────────
+
+echo "=== Codex provider support ==="
+
+if grep -q 'PROVIDER_CODEX_CONFIG_DIR=' "$MANAGE_SCRIPT"; then
+    assert "PROVIDER_CODEX_CONFIG_DIR is defined" "pass"
+else
+    assert "PROVIDER_CODEX_CONFIG_DIR is defined" "fail" \
+        "Expected PROVIDER_CODEX_CONFIG_DIR= in script"
+fi
+
+if grep -q 'PROVIDER_CODEX_CONFIG_ITEMS=' "$MANAGE_SCRIPT"; then
+    assert "PROVIDER_CODEX_CONFIG_ITEMS is defined" "pass"
+else
+    assert "PROVIDER_CODEX_CONFIG_ITEMS is defined" "fail" \
+        "Expected PROVIDER_CODEX_CONFIG_ITEMS= in script"
+fi
+
+if grep -q 'PROVIDER_CODEX_SHARED_ITEMS=' "$MANAGE_SCRIPT"; then
+    assert "PROVIDER_CODEX_SHARED_ITEMS is defined" "pass"
+else
+    assert "PROVIDER_CODEX_SHARED_ITEMS is defined" "fail" \
+        "Expected PROVIDER_CODEX_SHARED_ITEMS= in script"
+fi
+
+if grep -q 'usage_codex()' "$MANAGE_SCRIPT"; then
+    assert "usage_codex() function exists" "pass"
+else
+    assert "usage_codex() function exists" "fail"
+fi
+
+if grep -qE '^\s*(codex\)|.*\|codex[\|)])' "$MANAGE_SCRIPT"; then
+    assert "Agent 'codex' is handled in main case" "pass"
+else
+    assert "Agent 'codex' is handled in main case" "fail" \
+        "Expected codex case branch in main case statement"
 fi
 
 echo
@@ -478,6 +544,20 @@ else
         "Expected PROVIDER_CLAUDE_CONFIG_ITEMS= in script"
 fi
 
+if grep -q 'PROVIDER_CLAUDE_SHARED_ITEMS=' "$MANAGE_SCRIPT"; then
+    assert "PROVIDER_CLAUDE_SHARED_ITEMS is defined" "pass"
+else
+    assert "PROVIDER_CLAUDE_SHARED_ITEMS is defined" "fail" \
+        "Expected PROVIDER_CLAUDE_SHARED_ITEMS= in script"
+fi
+
+if grep -q 'SHARED_CONFIG_DIR=' "$MANAGE_SCRIPT"; then
+    assert "SHARED_CONFIG_DIR is defined" "pass"
+else
+    assert "SHARED_CONFIG_DIR is defined" "fail" \
+        "Expected SHARED_CONFIG_DIR= in script"
+fi
+
 if grep -q 'download_provider_config()' "$MANAGE_SCRIPT"; then
     assert "download_provider_config() function exists" "pass"
 else
@@ -488,6 +568,18 @@ if grep -q 'post_download_claude()' "$MANAGE_SCRIPT"; then
     assert "post_download_claude() post-hook exists" "pass"
 else
     assert "post_download_claude() post-hook exists" "fail"
+fi
+
+if grep -q 'post_download_gemini()' "$MANAGE_SCRIPT"; then
+    assert "post_download_gemini() post-hook exists" "pass"
+else
+    assert "post_download_gemini() post-hook exists" "fail"
+fi
+
+if grep -q 'post_download_codex()' "$MANAGE_SCRIPT"; then
+    assert "post_download_codex() post-hook exists" "pass"
+else
+    assert "post_download_codex() post-hook exists" "fail"
 fi
 
 echo

--- a/tests/test-validate-bash.sh
+++ b/tests/test-validate-bash.sh
@@ -11,11 +11,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/validate-bash.sh"
+GEMINI_HOOK="$REPO_ROOT/.gemini/hooks/validate-bash.sh"
+CODEX_HOOK="$REPO_ROOT/.codex/hooks/validate-bash.sh"
 TEST_CASES="$SCRIPT_DIR/bash-test-cases.toml"
 
 PASS=0
 FAIL=0
-SKIP=0
 ERRORS=()
 
 # Colors for output (if terminal supports it)
@@ -161,6 +162,49 @@ run_inline_tests() {
     echo
 }
 
+test_provider_smoke() {
+    local provider="$1"
+    local hook="$2"
+    local payload="$3"
+    local jq_filter="$4"
+    local expected="$5"
+
+    local result decision
+    result=$(printf '%s' "$payload" | bash "$hook" 2>/dev/null) || true
+    if [[ -z "$result" ]]; then
+        decision="allow"
+    else
+        decision=$(echo "$result" | jq -r "$jq_filter")
+    fi
+
+    if [[ "$decision" == "$expected" ]]; then
+        echo -e "  ${GREEN}✓${NC} ${provider} adapter smoke test"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}✗${NC} ${provider} adapter smoke test"
+        echo "    Expected: $expected, Got: $decision"
+        ERRORS+=("${provider} adapter smoke test: expected $expected, got $decision")
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+run_provider_smoke_tests() {
+    echo "Testing: Provider Adapter Smoke"
+    test_provider_smoke \
+        "Gemini" \
+        "$GEMINI_HOOK" \
+        "{\"tool_input\":{\"command\":\"git status\",\"directory\":\"$SCRIPT_DIR\"}}" \
+        '.decision // "error"' \
+        "allow"
+    test_provider_smoke \
+        "Codex" \
+        "$CODEX_HOOK" \
+        "{\"tool_input\":{\"command\":\"git push --force\",\"directory\":\"$SCRIPT_DIR\"}}" \
+        '.hookSpecificOutput.permissionDecision // "error"' \
+        "ask"
+    echo
+}
+
 # Main
 main() {
     echo "=== Bash Hook Test Suite ==="
@@ -186,6 +230,7 @@ main() {
 
     # Run inline edge case tests
     run_inline_tests
+    run_provider_smoke_tests
 
     # Summary
     echo "=== Summary ==="

--- a/tests/test_validate_bash.py
+++ b/tests/test_validate_bash.py
@@ -15,12 +15,13 @@ from unittest.mock import patch
 
 import pytest
 
-# Import validate-bash.py (hyphenated filename requires importlib)
-HOOKS_DIR = Path(__file__).parent.parent / ".claude" / "hooks"
+# Import the provider-neutral Bash policy engine (hyphenated filename requires importlib)
+HOOKS_DIR = Path(__file__).parent.parent / ".ai-dev-foundry" / "shared" / "hooks" / "bash-policy"
 _spec = importlib.util.spec_from_file_location(
-    "validate_bash", HOOKS_DIR / "validate-bash.py"
+    "validate_bash", HOOKS_DIR / "validate-command.py"
 )
 validate_bash = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = validate_bash
 _spec.loader.exec_module(validate_bash)
 
 # Python 3.11+ has tomllib built-in


### PR DESCRIPTION
## Summary
- move the Bash hook policy engine into .ai-dev-foundry/shared/hooks/bash-policy
- keep Claude as a thin adapter and add matching Gemini CLI and Codex adapters/config
- extend manage-ai-configs.sh, docs, and installer tests for the new provider layout
- document OpenCode as pending until it exposes a comparable project hook surface

## Verification
- pytest tests/test_validate_bash.py -q
- bash tests/test-validate-bash.sh
- bash tests/test-manage-agents.sh
- shellcheck .claude/hooks/*.sh .gemini/hooks/*.sh .codex/hooks/*.sh .ai-dev-foundry/shared/hooks/bash-policy/*.sh scripts/manage-ai-configs.sh