### PR TITLE
docs: slim down README, move per-agent detail and NotebookLM setup to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/amulya-labs/ai-dev-foundry/actions/workflows/ci.yml/badge.svg)](https://github.com/amulya-labs/ai-dev-foundry/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/amulya-labs/ai-dev-foundry/badge)](https://scorecard.dev/viewer/?uri=github.com/amulya-labs/ai-dev-foundry)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Agents](https://img.shields.io/badge/agents-22-blue.svg)](.claude/agents/)
+[![Agents](https://img.shields.io/badge/agents-25-blue.svg)](.claude/agents/)
 
 **Production-ready configuration for AI coding agents.** A shared set of agents, a cross-tool Bash-command policy, and GitHub Actions workflows you can drop into any project. Works across Claude Code, Codex CLI, Gemini CLI, and opencode.
 
@@ -21,9 +21,11 @@ See [docs/agents.md](docs/agents.md) for per-agent descriptions, domain grouping
 
 <table>
 <tr><th>Agent</th><th>Description</th><th>Model</th></tr>
-<tr><td>agent-specialist</td><td>Design and optimize AI agents with strong contracts</td><td rowspan="13">opus</td></tr>
+<tr><td>agent-specialist</td><td>Design and optimize AI agents with strong contracts</td><td rowspan="15">opus</td></tr>
+<tr><td>career-advisor</td><td>Career strategy: role targeting, resume, job search, and pivots</td></tr>
 <tr><td>claudemd-architect</td><td>Create and update CLAUDE.md files for agent-ready repos</td></tr>
 <tr><td>data-engineer</td><td>ETL/ELT pipelines, data modeling, orchestration, and data quality</td></tr>
+<tr><td>legal-counsel</td><td>Contract review, legal analysis, and policy drafting</td></tr>
 <tr><td>marketing-lead</td><td>Positioning, messaging, and go-to-market copy</td></tr>
 <tr><td>ml-architect</td><td>End-to-end ML system design and production ML decisions</td></tr>
 <tr><td>prod-engineer</td><td>Production incident response and reliability engineering</td></tr>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Agents](https://img.shields.io/badge/agents-22-blue.svg)](.claude/agents/)
 
-**Production-ready configuration for AI coding agents.** Agents, hooks, and settings you can drop into any project.
+**Production-ready configuration for AI coding agents.** A shared set of agents, a cross-tool Bash-command policy, and GitHub Actions workflows you can drop into any project. Works across Claude Code, Codex CLI, Gemini CLI, and opencode.
 
 ## Quick Install
 
@@ -13,74 +13,11 @@
 mkdir -p scripts && curl -fsSL -o scripts/manage-ai-configs.sh https://raw.githubusercontent.com/amulya-labs/ai-dev-foundry/main/scripts/manage-ai-configs.sh && chmod +x scripts/manage-ai-configs.sh && ./scripts/manage-ai-configs.sh claude install
 ```
 
-## What You Get
+See [Installation Options](#installation-options) below for git-subtree, manual-copy, and update flows.
 
-### Planning
-| Agent | What it does |
-|-------|--------------|
-| **tech-lead** | Breaks down work, creates implementation plans, makes technical decisions |
-| **systems-architect** | Explains architecture, analyzes change impact, maps data flows |
-| **product-owner** | Defines product direction, writes specs, prioritizes ruthlessly |
+## Agents
 
-### Building
-| Agent | What it does |
-|-------|--------------|
-| **senior-dev** | Implements features with production-quality code and tests |
-| **debugger** | Investigates bugs systematically with root cause analysis |
-| **refactoring-expert** | Improves code structure without changing behavior |
-| **prompt-engineer** | Crafts effective prompts for AI models |
-| **agent-specialist** | Designs and optimizes AI agents with strong contracts |
-
-### Quality
-| Agent | What it does |
-|-------|--------------|
-| **code-reviewer** | Reviews code for correctness, security, and maintainability |
-| **test-engineer** | Designs comprehensive test suites (unit, integration, e2e) |
-| **security-auditor** | Identifies vulnerabilities and recommends mitigations |
-
-### Operations
-| Agent | What it does |
-|-------|--------------|
-| **prod-engineer** | Triages incidents, diagnoses with evidence, hardens systems |
-| **pr-refiner** | Processes PR feedback and implements changes with critical thinking |
-| **documentation-writer** | Creates minimal, DRY documentation |
-| **claudemd-architect** | Creates and updates CLAUDE.md files for agent-ready repos |
-
-### Data & ML
-| Agent | What it does |
-|-------|--------------|
-| **data-engineer** | Designs and reviews ETL/ELT pipelines, data models, orchestration, and data quality strategies |
-| **ml-architect** | Designs ML systems end-to-end: data pipelines, training, serving, monitoring |
-
-### Design
-| Agent | What it does |
-|-------|--------------|
-| **ux-designer** | Research-backed UX critique covering usability, accessibility, information architecture, and business alignment |
-| **ui-developer** | Pixel-perfect UI implementation with design system thinking, animation performance, and component quality |
-| **digital-designer** | Creates print-ready layouts (booklets, brochures, posters) |
-
-### Sales / Solutions
-| Agent | What it does |
-|-------|--------------|
-| **solution-eng** | Runs discovery, designs solutions, manages POCs |
-| **marketing-lead** | Crafts positioning, messaging, and go-to-market copy that converts |
-
-## Usage
-
-Invoke agents with `@agent-name` in Claude Code:
-
-```
-@tech-lead plan how to add user notifications
-@senior-dev add pagination to the users endpoint
-@debugger the API returns 500 on POST /users
-@security-auditor review the authentication module
-@systems-architect how does caching work in this service?
-@code-reviewer check my changes before I open a PR
-```
-
-Claude can also select agents automatically based on your request.
-
-## Available Agents
+See [docs/agents.md](docs/agents.md) for per-agent descriptions, domain grouping, and usage examples.
 
 <table>
 <tr><th>Agent</th><th>Description</th><th>Model</th></tr>
@@ -109,8 +46,47 @@ Claude can also select agents automatically based on your request.
 <tr><td>junior-dev</td><td>Focused, well-scoped tasks for early-career developers</td><td>haiku</td></tr>
 </table>
 
+## Hooks
+
+A shared Bash-command validation engine lives in `.ai-dev-foundry/shared/hooks/bash-policy/`, with thin adapters in `.claude/hooks/`, `.gemini/hooks/`, and `.codex/hooks/` — so the same allow/ask/deny policy is reused across Claude Code, Codex CLI, and Gemini CLI without duplicating rules. opencode is still pending upstream support for a comparable project hook surface.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the hook architecture, pattern categories, OS overlays, and the Claude `settings.json` × hook precedence matrix.
+
+## GitHub Actions Workflows
+
+| Workflow | Purpose | Trigger |
+|----------|---------|---------|
+| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/review` or `/claude-review` comment |
+| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | `/review` or `/gemini-review` comment |
+| `sync-notebooklm.yml` | Flatten repo into text sources and sync to NotebookLM | Push to main; manual dispatch |
+
+All `*-code-review.yml` workflows opt in to the shared `/review` PR comment trigger alongside any agent-specific commands such as `/claude-review` or `/gemini-review`. If both Claude and Gemini review workflows are installed, `/review` triggers both — disable the other workflow or use the provider-specific trigger to run only one.
+
+**Gemini Code Review** needs a `GEMINI_API_KEY` repo secret. Flash drives the narrative PR summary; Pro drives line-level inline comments. Trigger manually with `/review` or `/gemini-review` on any PR (members/owners/collaborators only).
+
+**NotebookLM Sync** — see [docs/notebooklm-sync.md](docs/notebooklm-sync.md) for install, source configuration, and secret setup.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `manage-ai-configs.sh` | Install and update AI agent configs and GHA workflows via curl (no git knowledge needed) |
+| `git-subtree-mgr` | Manage git subtrees with history tracking (install globally in `~/bin`) |
+
+Run `./scripts/manage-ai-configs.sh` or `git-subtree-mgr --help` for usage.
+
+| Use case | Recommended |
+|----------|-------------|
+| Just want the agents, minimal setup | `manage-ai-configs.sh claude install` |
+| Also want Claude GitHub Actions workflows | `manage-ai-configs.sh claude install --with-gha-workflows` |
+| Want git history of upstream changes | `git-subtree-mgr` |
+| Managing multiple subtrees in a project | `git-subtree-mgr` |
+| Non-technical team members | `manage-ai-configs.sh claude install` |
+
+## Installation Options
+
 <details>
-<summary>Installation Options</summary>
+<summary>Expand for curl / git-subtree / manual options</summary>
 
 ### Option 1: Curl-based Script (Recommended)
 
@@ -145,132 +121,9 @@ cp -r ai-dev-foundry/.claude/ /path/to/your/project/.claude/
 
 </details>
 
-## Hooks
-
-The shared Bash command validation engine lives in `.ai-dev-foundry/shared/hooks/bash-policy/`. Thin adapters now live in `.claude/hooks/`, `.gemini/hooks/`, and `.codex/hooks/`, so the same allow/ask/deny policy can be reused across Claude Code, Gemini CLI, and Codex without duplicating rules. OpenCode is still pending because its current CLI docs do not expose a comparable project hook surface.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for hook configuration details.
-
-## Scripts
-
-| Script | Purpose |
-|--------|---------|
-| `manage-ai-configs.sh` | Install and update AI agent configs and GHA workflows via curl (no git knowledge needed) |
-| `git-subtree-mgr` | Manage git subtrees with history tracking (install globally in `~/bin`) |
-
-Run `./scripts/manage-ai-configs.sh` or `git-subtree-mgr --help` for usage.
-
-## GitHub Actions Workflows
-
-| Workflow | Purpose | Trigger |
-|----------|---------|---------|
-| `claude-code-review.yml` | Automated PR review using Claude | PR opened/updated; `/review` or `/claude-review` comment |
-| `gemini-code-review.yml` | Automated PR review using Gemini Flash + Pro | `/review` or `/gemini-review` comment |
-| `sync-notebooklm.yml` | Flatten repo into text sources and sync to NotebookLM | Push to main; manual dispatch |
-
-### Gemini Code Review Setup
-
-Add your Gemini API key as a repository secret named `GEMINI_API_KEY`. The workflow uses:
-- **Gemini Flash** for the narrative PR summary (fast, quota-efficient)
-- **Gemini Pro** for line-level inline comments (deep reasoning)
-
-Trigger manually by commenting `/review` or `/gemini-review` on any PR (members/owners/collaborators only).
-
-### Shared Review Command Convention
-
-All `*-code-review.yml` workflows should opt in to the shared `/review` PR comment trigger alongside any agent-specific commands such as `/claude-review` or `/gemini-review`. This keeps the default review fan-out convention-based and avoids a separate dispatcher workflow.
-
-If both Claude and Gemini review workflows are installed, `/review` triggers both of them. Teams that want a single reviewer should disable the other workflow or use the provider-specific trigger instead.
-
-### NotebookLM Sync
-
-Flattens your codebase into word-limited text sources using [repomix](https://github.com/yamadashy/repomix) and uploads them to a NotebookLM notebook on every push to main. Useful for keeping a "project brain" notebook up to date without manual effort.
-
-**Install:**
-
-```bash
-./scripts/manage-ai-configs.sh notebooklm install
-```
-
-This installs `.github/workflows/sync-notebooklm.yml` and `.github/repomix.config.json`.
-
-**Configure sources:**
-
-Create `.github/notebooklm-sources.yaml` (template at [`examples/notebooklm-sources.yaml`](examples/notebooklm-sources.yaml)). Each entry becomes a separate source in the notebook. NotebookLM allows up to 300 sources at 500,000 words each.
-
-```yaml
-sources:
-  - name: my-app-core
-    include: ["src/**"]
-    ignore: ["src/tests/**"]
-
-  - name: my-app-tests
-    include: ["tests/**"]
-
-  - name: my-app-docs
-    include: ["docs/**", "README.md"]
-```
-
-<details>
-<summary>Source splitting patterns</summary>
-
-**Split a large src/ by subfolder** when a single `src/**` source would exceed 500k words:
-
-```yaml
-sources:
-  - name: app-services
-    include: ["src/services/**"]
-
-  - name: app-models
-    include: ["src/models/**"]
-
-  - name: app-api
-    include: ["src/api/**"]
-
-  # Catch-all for anything not in the above folders
-  - name: app-core
-    include: ["src/**"]
-    ignore: ["src/services/**", "src/models/**", "src/api/**"]
-```
-
-**Monorepo with multiple packages:**
-
-```yaml
-sources:
-  - name: pkg-auth
-    include: ["packages/auth/**"]
-
-  - name: pkg-billing
-    include: ["packages/billing/**"]
-
-  - name: pkg-shared
-    include: ["packages/shared/**"]
-
-  - name: repo-root
-    include: ["*.json", "*.yaml", "*.md", ".github/**"]
-```
-
-</details>
-
-**Add secrets** (Settings → Secrets and variables → Actions):
-
-| Secret | How to get it |
-|--------|--------------|
-| `NLM_COOKIES_JSON` | `pip install notebooklm-mcp-cli && nlm login`, then `cat ~/.notebooklm-mcp-cli/profiles/default/cookies.json` |
-| `NLM_NOTEBOOK_ID` | `nlm notebook list --quiet` or `nlm notebook create "My Project Brain"` |
-
-Push both secrets with `gh secret set`:
-
-```bash
-gh secret set NLM_COOKIES_JSON --repo <owner>/<repo> < ~/.notebooklm-mcp-cli/profiles/default/cookies.json
-echo -n 'YOUR-NOTEBOOK-UUID' | gh secret set NLM_NOTEBOOK_ID --repo <owner>/<repo>
-```
-
-Cookies expire every few weeks. When they do, the workflow fails with step-by-step refresh instructions in the job log.
-
 ## Contributing
 
-PRs welcome. Agents should be generalized (no project-specific references), focused (one domain per agent), and well-structured. See [CONTRIBUTING.md](CONTRIBUTING.md) for the agent file format and guidelines.
+PRs welcome. Agents should be generalized (no project-specific references), focused (one domain per agent), and well-structured. See [CONTRIBUTING.md](CONTRIBUTING.md) for the agent file format, hook architecture, and guidelines.
 
 ## License
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -15,6 +15,7 @@ Full catalog of agents shipped by ai-dev-foundry, grouped by domain. The top-lev
 | Agent | What it does |
 |-------|--------------|
 | **senior-dev** | Implements features with production-quality code and tests |
+| **junior-dev** | Implements straightforward features and fixes simple bugs; suited for focused, well-scoped tasks |
 | **debugger** | Investigates bugs systematically with root cause analysis |
 | **refactoring-expert** | Improves code structure without changing behavior |
 | **prompt-engineer** | Crafts effective prompts for AI models |
@@ -59,9 +60,16 @@ Full catalog of agents shipped by ai-dev-foundry, grouped by domain. The top-lev
 | **solution-eng** | Runs discovery, designs solutions, manages POCs |
 | **marketing-lead** | Crafts positioning, messaging, and go-to-market copy that converts |
 
+## Professional
+
+| Agent | What it does |
+|-------|--------------|
+| **career-advisor** | Diagnoses market position and produces ROI-ranked actions for role targeting, resume strategy, and career pivots |
+| **legal-counsel** | Analyzes legal issues, reviews contracts, and drafts legal work product with strict anti-hallucination and jurisdiction discipline |
+
 ## Usage
 
-Invoke agents with `@agent-name` in Claude Code:
+`@agent-name` is a Claude Code invocation pattern. For Gemini CLI and Codex CLI, agents are selected automatically based on your request; explicit `@agent-name` targeting is not required.
 
 ```
 @tech-lead plan how to add user notifications
@@ -71,5 +79,3 @@ Invoke agents with `@agent-name` in Claude Code:
 @systems-architect how does caching work in this service?
 @code-reviewer check my changes before I open a PR
 ```
-
-Claude can also select agents automatically based on your request.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,75 @@
+# Agents
+
+Full catalog of agents shipped by ai-dev-foundry, grouped by domain. The top-level [README](../README.md) has the compact table; this doc has per-agent descriptions and usage examples.
+
+## Planning
+
+| Agent | What it does |
+|-------|--------------|
+| **tech-lead** | Breaks down work, creates implementation plans, makes technical decisions |
+| **systems-architect** | Explains architecture, analyzes change impact, maps data flows |
+| **product-owner** | Defines product direction, writes specs, prioritizes ruthlessly |
+
+## Building
+
+| Agent | What it does |
+|-------|--------------|
+| **senior-dev** | Implements features with production-quality code and tests |
+| **debugger** | Investigates bugs systematically with root cause analysis |
+| **refactoring-expert** | Improves code structure without changing behavior |
+| **prompt-engineer** | Crafts effective prompts for AI models |
+| **agent-specialist** | Designs and optimizes AI agents with strong contracts |
+
+## Quality
+
+| Agent | What it does |
+|-------|--------------|
+| **code-reviewer** | Reviews code for correctness, security, and maintainability |
+| **test-engineer** | Designs comprehensive test suites (unit, integration, e2e) |
+| **security-auditor** | Identifies vulnerabilities and recommends mitigations |
+
+## Operations
+
+| Agent | What it does |
+|-------|--------------|
+| **prod-engineer** | Triages incidents, diagnoses with evidence, hardens systems |
+| **pr-refiner** | Processes PR feedback and implements changes with critical thinking |
+| **documentation-writer** | Creates minimal, DRY documentation |
+| **claudemd-architect** | Creates and updates CLAUDE.md files for agent-ready repos |
+
+## Data & ML
+
+| Agent | What it does |
+|-------|--------------|
+| **data-engineer** | Designs and reviews ETL/ELT pipelines, data models, orchestration, and data quality strategies |
+| **ml-architect** | Designs ML systems end-to-end: data pipelines, training, serving, monitoring |
+
+## Design
+
+| Agent | What it does |
+|-------|--------------|
+| **ux-designer** | Research-backed UX critique covering usability, accessibility, information architecture, and business alignment |
+| **ui-developer** | Pixel-perfect UI implementation with design system thinking, animation performance, and component quality |
+| **digital-designer** | Creates print-ready layouts (booklets, brochures, posters) |
+
+## Sales / Solutions
+
+| Agent | What it does |
+|-------|--------------|
+| **solution-eng** | Runs discovery, designs solutions, manages POCs |
+| **marketing-lead** | Crafts positioning, messaging, and go-to-market copy that converts |
+
+## Usage
+
+Invoke agents with `@agent-name` in Claude Code:
+
+```
+@tech-lead plan how to add user notifications
+@senior-dev add pagination to the users endpoint
+@debugger the API returns 500 on POST /users
+@security-auditor review the authentication module
+@systems-architect how does caching work in this service?
+@code-reviewer check my changes before I open a PR
+```
+
+Claude can also select agents automatically based on your request.

--- a/docs/notebooklm-sync.md
+++ b/docs/notebooklm-sync.md
@@ -1,0 +1,84 @@
+# NotebookLM Sync
+
+Flattens your codebase into word-limited text sources using [repomix](https://github.com/yamadashy/repomix) and uploads them to a NotebookLM notebook on every push to main. Useful for keeping a "project brain" notebook up to date without manual effort.
+
+## Install
+
+```bash
+./scripts/manage-ai-configs.sh notebooklm install
+```
+
+This installs `.github/workflows/sync-notebooklm.yml` and `.github/repomix.config.json`.
+
+## Configure sources
+
+Create `.github/notebooklm-sources.yaml` (template at [`examples/notebooklm-sources.yaml`](../examples/notebooklm-sources.yaml)). Each entry becomes a separate source in the notebook. NotebookLM allows up to 300 sources at 500,000 words each.
+
+```yaml
+sources:
+  - name: my-app-core
+    include: ["src/**"]
+    ignore: ["src/tests/**"]
+
+  - name: my-app-tests
+    include: ["tests/**"]
+
+  - name: my-app-docs
+    include: ["docs/**", "README.md"]
+```
+
+### Source splitting patterns
+
+**Split a large src/ by subfolder** when a single `src/**` source would exceed 500k words:
+
+```yaml
+sources:
+  - name: app-services
+    include: ["src/services/**"]
+
+  - name: app-models
+    include: ["src/models/**"]
+
+  - name: app-api
+    include: ["src/api/**"]
+
+  # Catch-all for anything not in the above folders
+  - name: app-core
+    include: ["src/**"]
+    ignore: ["src/services/**", "src/models/**", "src/api/**"]
+```
+
+**Monorepo with multiple packages:**
+
+```yaml
+sources:
+  - name: pkg-auth
+    include: ["packages/auth/**"]
+
+  - name: pkg-billing
+    include: ["packages/billing/**"]
+
+  - name: pkg-shared
+    include: ["packages/shared/**"]
+
+  - name: repo-root
+    include: ["*.json", "*.yaml", "*.md", ".github/**"]
+```
+
+## Add secrets
+
+Settings → Secrets and variables → Actions:
+
+| Secret | How to get it |
+|--------|--------------|
+| `NLM_COOKIES_JSON` | `pip install notebooklm-mcp-cli && nlm login`, then `cat ~/.notebooklm-mcp-cli/profiles/default/cookies.json` |
+| `NLM_NOTEBOOK_ID` | `nlm notebook list --quiet` or `nlm notebook create "My Project Brain"` |
+
+Push both secrets with `gh secret set`:
+
+```bash
+gh secret set NLM_COOKIES_JSON --repo <owner>/<repo> < ~/.notebooklm-mcp-cli/profiles/default/cookies.json
+echo -n 'YOUR-NOTEBOOK-UUID' | gh secret set NLM_NOTEBOOK_ID --repo <owner>/<repo>
+```
+
+Cookies expire every few weeks. When they do, the workflow fails with step-by-step refresh instructions in the job log.


### PR DESCRIPTION
## Summary

- Re-sequences README around value prop → quickstart → agent table → hooks → workflows → scripts → install options
- Moves per-category agent descriptions and `@agent-name` usage examples to `docs/agents.md`
- Moves long-form NotebookLM sync setup (source config, secrets, cookie refresh) to `docs/notebooklm-sync.md`
- Tightens value-prop line to name the cross-tool scope (Claude Code, Codex CLI, Gemini CLI, opencode)
- No behavior changes; no scripts, hooks, workflow files, or agent definitions touched

README drops from 277 lines to ~134 while keeping the canonical agent reference table and all install paths. Long-form content is linked out, not deleted.

## Why

The README was carrying three kinds of content at once: a value-prop / install doc (the job of a README), a full agent catalog with duplicated per-category descriptions, and install/config docs for a single GHA workflow (NotebookLM). The top of the file gave first-time visitors a wall of agent descriptions before the install/scope story. Product-owner review recommended slimming, re-sequencing, and linking out.

## Follow-up

#104 tracks adding a tiered "hook-as-primary-gate" install section (per-tool YOLO invocations with `deny`-still-fires caveat and platform notes). Intentionally out of scope here.

## Test plan

- [x] `shellcheck` on all hook scripts — clean
- [x] `bash-patterns.toml` parses as valid TOML
- [x] `pytest tests/test_validate_bash.py` — 807 passed
- [x] `tests/test-validate-bash.sh` — passes
- [x] `tests/test-manage-agents.sh` — passes
- [ ] Visual check: render README.md, docs/agents.md, docs/notebooklm-sync.md on GitHub after push
- [ ] Verify all in-README links resolve (docs/agents.md, docs/notebooklm-sync.md, CONTRIBUTING.md, anchor to #installation-options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)