### PR TITLE
ci(claude-review): skip auto-review on draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,7 @@ jobs:
       (
         github.event.repository.visibility != 'public' && (
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false) ||
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
@@ -72,6 +72,7 @@ jobs:
           (
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.draft == false &&
             (
               github.event.pull_request.author_association == 'MEMBER' ||
               github.event.pull_request.author_association == 'OWNER' ||


### PR DESCRIPTION
## Summary
- Skip Claude auto code review while a PR is in draft.
- Reviews still trigger when the PR is marked **ready for review** (already in the trigger types) or via `/review`, `/claude-review`, or workflow_dispatch.

## Test plan
- [ ] Open a draft PR → workflow job is skipped (no review-started comment).
- [ ] Mark the PR ready → workflow runs.
- [ ] `/review` on a draft PR still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)